### PR TITLE
Implement elimination of left recursions context-free grammars

### DIFF
--- a/docs/3-parser_theory.md
+++ b/docs/3-parser_theory.md
@@ -895,6 +895,109 @@ In fact, the notion of least-cost correction provides a benchmark for evaluating
 
 ## Core Algorithms
 
+### Identifying Nullable Non-Terminals
+
+```
+# INPUT:  Grammar G.
+# OUTPUT: A set of nullable non-terminals.
+# METHOD:
+#
+#   1. Initialize an empty set nullable = {}
+#
+#   2. For each production A → ε of the grammar:
+#        • Add A to nullable.
+#
+#   3. Repeat until no new non-terminals are added to nullable:
+#        For each production A → A₁A₂...Aₙ of the grammar, where A ∉ nullable:
+#          • Add A to nullable if all Aᵢ ∈ nullable.
+#
+```
+
+### Eliminating Empty Productions
+
+```
+# INPUT:  Grammar G.
+# OUTPUT: An equivalent ε-free grammar.
+# METHOD:
+#
+#   1. Identify all nullable non-terminals of the grammar.
+#
+#   2. For each production A → α of the grammar:
+#        • Generate all possible combinations of α by including and excluding nullable non-terminals of α (α₁α₂...αₙ).
+#        • For each combination αᵢ:
+#            • If αᵢ ≠ ε, add the production A → αᵢ to the new grammar (if not already added).
+#
+#   3. If the start symbol S ∈ nullable,
+#        • Add a new non-termnial S′ to the grammar
+#        • Add a new production S′ → S | ε to the grammar.
+#        • Set the start symbol of the new grammar to S′.
+#
+```
+
+### Eliminating Single Productions
+
+```
+# INPUT:  Grammar G.
+# OUTPUT: An equivalent grammar with no single productions.
+# METHOD:
+#
+#   1. Identify all single productions:
+#        • Initialize an empty map singles = {}
+#        • For each production A → α of the grammar:
+#            • If α is a single non-terminal B, add B to the set singles[A].
+#
+#   2. Compute the transitive closure of non-terminals:
+#        • Initialze an empty map closure = {}
+#        • For each non-terminal A:
+#            • Set closure[A][A] = true
+#        • For each single production A → B in singles:
+#            • Set closure[A][B] = true
+#
+#   3. Repeat until no new non-terminals are added to closure:
+#        • For every non-terminal A in closure:
+#            • For every non-terminal B in closure[A]:
+#                • For every non-terminal C in closure[B]:
+#                    • Set closure[A][C] = true
+#
+#   4. For every non-terminal A in closure:
+#        • For every non-terminal B in closure[A]:
+#            • For every production B → β:
+#                • If β is not a single non-terminal, add production A → β to the new grammar.
+#
+```
+
+### Eliminating Unreachable Productions
+
+```
+# INPUT:  Grammar G.
+# OUTPUT: An equivalent grammar with no unreachable productions.
+# METHOD:
+#
+#   1. Initialize a set reachable = {S}, where S is the start symbol of the grammar.
+#
+#   2. Repeat until no new non-terminals are added to reachable:
+#        • For each production A → α of the grammar, where A ∉ reachable:
+#            • For each non-terminal B in α:
+#                • If B ∉ reachable, add B to reachable.
+#
+#   3. For each production A → α of the grammar, where A ∈ reachable:
+#        • Add production A → α to the new grammar.
+#
+```
+
+### Eliminating Cycles
+
+```
+# INPUT:  Grammar G.
+# OUTPUT: An equivalent cycle-free grammar.
+# METHOD: 
+#
+#   1. Eliminate empty productions.
+#   2. Eliminate single productions.
+#   3. Eliminate unreachable productions.
+#
+```
+
 ### Eliminating Left Recursion
 
 ```
@@ -918,7 +1021,7 @@ for (each i from 1 to n)
 ```
 # INPUT:  Grammar G.
 # OUTPUT: An equivalent left-factored grammar.
-# METHOD: For each non-terminal A, finnd the longest prefix α common to two or more of its alternatives.
+# METHOD: For each non-terminal A, find the longest prefix α common to two or more of its alternatives.
 #         If α ≠ ε, there is a non-trivial common prefix, replace all of the A-productions
 #         A → αβ₁ | αβ₂ | ... | αβₙ | γ where γ represents all alternatives that do not begin with α by
 #

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.4
 require (
 	github.com/gardenbed/charm v0.1.4
 	github.com/mitchellh/cli v1.1.5
-	github.com/moorara/algo v0.8.2
+	github.com/moorara/algo v0.9.1
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -31,7 +31,7 @@ require (
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
-	golang.org/x/exp v0.0.0-20241210194714-1829a127f884 // indirect
+	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect
 	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMK
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moorara/algo v0.8.2 h1:NRIQu6tl6LdKki1zS2/4uprrrr5vC2UEejkeCvB7B0Q=
-github.com/moorara/algo v0.8.2/go.mod h1:20tKMo9woCpxdQKW0coCI0EogL0feqxztIcPWRx3AOo=
+github.com/moorara/algo v0.9.1 h1:vua6nTwkwd5zmU7e1zr37EpXsZzCobMvFxaJeigmA5w=
+github.com/moorara/algo v0.9.1/go.mod h1:q0JdDdAOQrbIxumm1qouF72KmSAKl+glzGqc/DFAQfw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1 h1:ccV59UEOTzVDnDUEFdT95ZzHVZ+5+158q8+SJb2QV5w=
@@ -57,8 +57,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/exp v0.0.0-20241210194714-1829a127f884 h1:Y/Mj/94zIQQGHVSv1tTtQBDaQaJe62U9bkDZKKyhPCU=
-golang.org/x/exp v0.0.0-20241210194714-1829a127f884/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 h1:1UoZQm6f0P/ZO0w1Ri+f+ifG/gXhegadRdwBIXEFWDo=
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=

--- a/internal/grammar/grammar.go
+++ b/internal/grammar/grammar.go
@@ -2,205 +2,14 @@
 package grammar
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
-	"iter"
-	"slices"
-	"strings"
 
 	"github.com/moorara/algo/generic"
-	"github.com/moorara/algo/hash"
 	"github.com/moorara/algo/set"
 	"github.com/moorara/algo/sort"
-	"github.com/moorara/algo/symboltable"
 )
-
-// The empty string ε
-var ε = String[Symbol]{}
-
-var (
-	eqTerminal      = generic.NewEqualFunc[Terminal]()
-	eqNonTerminal   = generic.NewEqualFunc[NonTerminal]()
-	cmpString       = generic.NewCompareFunc[string]()
-	cmpNonTerminal  = generic.NewCompareFunc[NonTerminal]()
-	hashNonTerminal = hash.HashFuncForString[NonTerminal](nil)
-
-	eqProduction = func(lhs, rhs Production) bool {
-		return lhs.Equals(rhs)
-	}
-
-	eqProductionSet = func(lhs, rhs set.Set[Production]) bool {
-		return lhs.Equals(rhs)
-	}
-)
-
-// Symbol represents a grammar symbol (terminal or non-terminal).
-type Symbol interface {
-	fmt.Stringer
-
-	Name() string
-	Equals(Symbol) bool
-	IsTerminal() bool
-}
-
-// Terminal represents a terminal symbol.
-// Terminals are the basic symbols from which strings of a language are formed.
-// Token name or token for short are equivalent to terminal.
-type Terminal string
-
-// String implements the fmt.Stringer interface.
-func (t Terminal) String() string {
-	return t.Name()
-}
-
-// Name returns the name of terminal symbol.
-func (t Terminal) Name() string {
-	return string(t)
-}
-
-// Equals determines whether or not two terminal symbols are the same.
-func (t Terminal) Equals(rhs Symbol) bool {
-	if v, ok := rhs.(Terminal); ok {
-		return t == v
-	}
-	return false
-}
-
-// IsTerminal always returns true for terminal symbols.
-func (t Terminal) IsTerminal() bool {
-	return true
-}
-
-// NonTerminal represents a non-terminal symbol.
-// Non-terminals are syntaxtic variables that denote sets of strings.
-// Non-terminals impose a hierarchical structure on a language.
-type NonTerminal string
-
-// String implements the fmt.Stringer interface.
-func (n NonTerminal) String() string {
-	return n.Name()
-}
-
-// Name returns the name of non-terminal symbol.
-func (n NonTerminal) Name() string {
-	return string(n)
-}
-
-// Equals determines whether or not two non-terminal symbols are the same.
-func (n NonTerminal) Equals(rhs Symbol) bool {
-	if v, ok := rhs.(NonTerminal); ok {
-		return n == v
-	}
-	return false
-}
-
-// IsTerminal always returns false for non-terminal symbols.
-func (n NonTerminal) IsTerminal() bool {
-	return false
-}
-
-// String represent a string of grammar symbols.
-type String[T Symbol] []T
-
-// String implements the fmt.Stringer interface.
-func (s String[T]) String() string {
-	if len(s) == 0 {
-		return "ε"
-	}
-
-	names := make([]string, len(s))
-	for i, symbol := range s {
-		names[i] = symbol.Name()
-	}
-
-	return strings.Join(names, " ")
-}
-
-// Equals determines whether or not two strings are the same.
-func (s String[T]) Equals(rhs String[T]) bool {
-	if len(s) != len(rhs) {
-		return false
-	}
-
-	for i := range s {
-		if !s[i].Equals(rhs[i]) {
-			return false
-		}
-	}
-
-	return true
-}
-
-// Terminals returns all terminal symbols of a string of symbols.
-func (s String[Symbol]) Terminals() String[Terminal] {
-	terms := String[Terminal]{}
-	for _, sym := range s {
-		if v, ok := any(sym).(Terminal); ok {
-			terms = append(terms, v)
-		}
-	}
-	return terms
-}
-
-// NonTerminals returns all non-terminal symbols of a string of symbols.
-func (s String[Symbol]) NonTerminals() String[NonTerminal] {
-	nonTerms := String[NonTerminal]{}
-	for _, sym := range s {
-		if v, ok := any(sym).(NonTerminal); ok {
-			nonTerms = append(nonTerms, v)
-		}
-	}
-	return nonTerms
-}
-
-// Production represents a production rule.
-// The productions of a grammar determine how the terminals and non-terminals can be combined to form strings.
-type Production struct {
-	// Head or left side defines some of the strings denoted by the non-terminal symbol.
-	Head NonTerminal
-	// Body or right side describes one way in which strings of the non-terminal at the head can be constructed.
-	Body String[Symbol]
-}
-
-// String implements the fmt.Stringer interface.
-func (p Production) String() string {
-	if len(p.Body) == 0 {
-		return fmt.Sprintf("%s → ε", p.Head)
-	}
-	return fmt.Sprintf("%s → %s", p.Head, p.Body)
-}
-
-// Equals determines whether or not two production rules are the same.
-func (p Production) Equals(rhs Production) bool {
-	return p.Head.Equals(rhs.Head) && p.Body.Equals(rhs.Body)
-}
-
-// IsEmpty determines whether or not a production rule is an empty production (ε-production).
-//
-// An empty production (ε-production) is any production of the form A → ε.
-func (p Production) IsEmpty() bool {
-	return len(p.Body) == 0
-}
-
-// IsSingle determines whether or not a production rule is a single production (unit production).
-//
-// A single production (unit production) is a production whose body is a single non-terminal (A → B).
-func (p Production) IsSingle() bool {
-	return len(p.Body) == 1 && !p.Body[0].IsTerminal()
-}
-
-// Productions represents a mapping of non-terminal symbols to their corresponding production rules.
-type Productions symboltable.SymbolTable[NonTerminal, set.Set[Production]]
-
-// NewProductions creates a new instance of the Productions type.
-func NewProductions() Productions {
-	return symboltable.NewQuadraticHashTable[NonTerminal, set.Set[Production]](
-		hashNonTerminal,
-		eqNonTerminal,
-		eqProductionSet,
-		symboltable.HashOpts{},
-	)
-}
 
 // Grammar represents a context-free grammar in formal language theory.
 type Grammar struct {
@@ -221,34 +30,9 @@ func New(terms []Terminal, nonTerms []NonTerminal, prods []Production, start Non
 
 	g.Terminals.Add(terms...)
 	g.NonTerminals.Add(nonTerms...)
-	g.AddProduction(prods...)
+	g.Productions.Add(prods...)
 
 	return g
-}
-
-// AddProduction adds one or more productions to a context-free grammar.
-func (g Grammar) AddProduction(ps ...Production) {
-	for _, p := range ps {
-		if _, ok := g.Productions.Get(p.Head); !ok {
-			g.Productions.Put(p.Head, set.New[Production](eqProduction))
-		}
-
-		list, _ := g.Productions.Get(p.Head)
-		list.Add(p)
-	}
-}
-
-// AllProductions returns an iterator that yields all productions in the context-free grammar.
-func (g Grammar) AllProductions() iter.Seq[Production] {
-	return func(yield func(Production) bool) {
-		for _, list := range g.Productions.All() {
-			for p := range list.All() {
-				if !yield(p) {
-					return
-				}
-			}
-		}
-	}
 }
 
 // verify takes a context-free grammar and determines whether or not it is valid.
@@ -256,49 +40,43 @@ func (g Grammar) AllProductions() iter.Seq[Production] {
 func (g Grammar) Verify() error {
 	var err error
 
-	getPredicate := func(n NonTerminal) generic.Predicate2[NonTerminal, set.Set[Production]] {
-		return func(head NonTerminal, _ set.Set[Production]) bool {
-			return head.Equals(n)
+	getPredicate := func(n NonTerminal) generic.Predicate1[Production] {
+		return func(p Production) bool {
+			return p.Head.Equals(n)
 		}
 	}
 
 	// Check if the start symbol is in the set of non-terminal symbols.
 	if !g.NonTerminals.Contains(g.Start) {
-		err = errors.Join(err, fmt.Errorf("start symbol %q not in the set of non-terminal symbols", g.Start))
+		err = errors.Join(err, fmt.Errorf("start symbol %s not in the set of non-terminal symbols", g.Start))
 	}
 
 	// Check if there is at least one production rule for the start symbol.
 	if !g.Productions.AnyMatch(getPredicate(g.Start)) {
-		err = errors.Join(err, fmt.Errorf("no production rule for start symbol %q", g.Start))
+		err = errors.Join(err, fmt.Errorf("no production rule for start symbol %s", g.Start))
 	}
 
 	// Check if there is at least one prodcution rule for every non-terminal symbol.
 	for n := range g.NonTerminals.All() {
 		if !g.Productions.AnyMatch(getPredicate(n)) {
-			err = errors.Join(err, fmt.Errorf("no production rule for non-terminal symbol %q", n))
+			err = errors.Join(err, fmt.Errorf("no production rule for non-terminal symbol %s", n))
 		}
 	}
 
-	for head, list := range g.Productions.All() {
+	for p := range g.Productions.All() {
 		// Check if the head of production rule is in the set of non-terminal symbols.
-		if !g.NonTerminals.Contains(head) {
-			err = errors.Join(err, fmt.Errorf("production head %q not in the set of non-terminal symbols", head))
+		if !g.NonTerminals.Contains(p.Head) {
+			err = errors.Join(err, fmt.Errorf("production head %s not in the set of non-terminal symbols", p.Head))
 		}
 
-		for p := range list.All() {
-			if !p.Head.Equals(head) {
-				err = errors.Join(err, fmt.Errorf("production head %q not matching %q", p.Head, head))
+		// Check if every symbol in the body of production rule is either in the set of terminal or non-terminal symbols.
+		for _, s := range p.Body {
+			if v, ok := s.(Terminal); ok && !g.Terminals.Contains(v) {
+				err = errors.Join(err, fmt.Errorf("terminal symbol %s not in the set of terminal symbols", v))
 			}
 
-			// Check if every symbol in the body of production rule is either in the set of terminal or non-terminal symbols.
-			for _, s := range p.Body {
-				if v, ok := s.(Terminal); ok && !g.Terminals.Contains(v) {
-					err = errors.Join(err, fmt.Errorf("terminal symbol %q not in the set of terminal symbols", v))
-				}
-
-				if v, ok := s.(NonTerminal); ok && !g.NonTerminals.Contains(v) {
-					err = errors.Join(err, fmt.Errorf("non-terminal symbol %q not in the set of non-terminal symbols", v))
-				}
+			if v, ok := s.(NonTerminal); ok && !g.NonTerminals.Contains(v) {
+				err = errors.Join(err, fmt.Errorf("non-terminal symbol %s not in the set of non-terminal symbols", v))
 			}
 		}
 	}
@@ -325,7 +103,7 @@ func (g Grammar) nullableNonTerminals() set.Set[NonTerminal] {
 
 		// Iterate through each production rule of the form A → α,
 		// where A is a non-terminal symbol and α is a string of terminals and non-terminals.
-		for head, list := range g.Productions.All() {
+		for head, list := range g.Productions.AllByHead() {
 			// Skip the production rule if A is already in the nullable set.
 			if nullable.Contains(head) {
 				continue
@@ -354,7 +132,7 @@ func (g Grammar) nullableNonTerminals() set.Set[NonTerminal] {
 func (g Grammar) EliminateEmptyProductions() Grammar {
 	nullable := g.nullableNonTerminals()
 
-	newGrammar := Grammar{
+	newG := Grammar{
 		Terminals:    g.Terminals.Clone(),
 		NonTerminals: g.NonTerminals.Clone(),
 		Productions:  NewProductions(),
@@ -363,8 +141,8 @@ func (g Grammar) EliminateEmptyProductions() Grammar {
 
 	// Iterate through each production rule in the input grammar.
 	// For each production rule of the form A → α,
-	//   generate all possible combinations of α, excluding symbols that are in the nullable set.
-	for p := range g.AllProductions() {
+	//   generate all possible combinations of α by including and excluding nullable non-terminals.
+	for p := range g.Productions.All() {
 		// Ignore ε-production rules (A → ε)
 		// Only consider the production rules of the form A → α
 		if p.IsEmpty() {
@@ -392,7 +170,7 @@ func (g Grammar) EliminateEmptyProductions() Grammar {
 		for _, β := range bodies {
 			// Skip ε-production rules (A → ε)
 			if len(β) > 0 {
-				newGrammar.AddProduction(Production{p.Head, β})
+				newG.Productions.Add(Production{p.Head, β})
 			}
 		}
 	}
@@ -403,16 +181,18 @@ func (g Grammar) EliminateEmptyProductions() Grammar {
 	// If the start symbol of the grammer is nullable (S ⇒* ε),
 	//   a new start symbol with an ε-production rule must be introduced (S′ → S | ε).
 	// This guarantees that the resulting grammar generates the same language as the original grammar.
-	if nullable.Contains(g.Start) {
-		newStart, _ := g.generateNewNonTerminal(g.Start, "′", "_new")
+	if start := newG.Start; nullable.Contains(start) {
+		newStart, ok := newG.addNewNonTerminal(start, "′", "″", "_new")
+		if !ok {
+			panic(fmt.Sprintf("Failed to generate a new non-terminal for %s", start))
+		}
 
-		newGrammar.Start = newStart
-		newGrammar.NonTerminals.Add(newStart)
-		newGrammar.AddProduction(Production{newStart, String[Symbol]{g.Start}}) // S′ → S
-		newGrammar.AddProduction(Production{newStart, ε})                       // S′ → ε
+		newG.Start = newStart
+		newG.Productions.Add(Production{newStart, String[Symbol]{start}}) // S′ → S
+		newG.Productions.Add(Production{newStart, ε})                     // S′ → ε
 	}
 
-	return newGrammar
+	return newG
 }
 
 // EliminateSingleProductions converts a context-free grammar into an equivalent single-production-free grammar.
@@ -421,7 +201,7 @@ func (g Grammar) EliminateEmptyProductions() Grammar {
 func (g Grammar) EliminateSingleProductions() Grammar {
 	// Identify all single productions.
 	singleProds := map[NonTerminal][]NonTerminal{}
-	for p := range g.AllProductions() {
+	for p := range g.Productions.All() {
 		if p.IsSingle() {
 			singleProds[p.Head] = append(singleProds[p.Head], p.Body[0].(NonTerminal))
 		}
@@ -431,7 +211,7 @@ func (g Grammar) EliminateSingleProductions() Grammar {
 	// The transitive closure of a non-terminal A is the the set of all non-terminals B
 	//   such that there exists a sequence of single productions starting from A and reaching B (i.e., A → B₁ → B₂ → ... → B).
 
-	closure := make(map[NonTerminal]map[NonTerminal]bool, g.NonTerminals.Cardinality())
+	closure := make(map[NonTerminal]map[NonTerminal]bool, g.NonTerminals.Size())
 
 	// Initially, each non-terminal symbol is reachable from itself.
 	for A := range g.NonTerminals.All() {
@@ -461,7 +241,7 @@ func (g Grammar) EliminateSingleProductions() Grammar {
 		}
 	}
 
-	newGrammar := Grammar{
+	newG := Grammar{
 		Terminals:    g.Terminals.Clone(),
 		NonTerminals: g.NonTerminals.Clone(),
 		Productions:  NewProductions(),
@@ -472,17 +252,16 @@ func (g Grammar) EliminateSingleProductions() Grammar {
 	//   if p is not a single production and B is in the transitive closure set of A.
 	for A, closureA := range closure {
 		for B := range closureA {
-			list, _ := g.Productions.Get(B)
-			for p := range list.All() {
+			for p := range g.Productions.Get(B).All() {
 				// Skip single productions
 				if !p.IsSingle() {
-					newGrammar.AddProduction(Production{A, p.Body})
+					newG.Productions.Add(Production{A, p.Body})
 				}
 			}
 		}
 	}
 
-	return newGrammar
+	return newG
 }
 
 // EliminateUnreachableProductions converts a context-free grammar into an equivalent grammar
@@ -500,7 +279,7 @@ func (g Grammar) EliminateUnreachableProductions() Grammar {
 	for updated := true; updated; {
 		updated = false
 
-		for p := range g.AllProductions() {
+		for p := range g.Productions.All() {
 			if reachable.Contains(p.Head) {
 				for _, n := range p.Body.NonTerminals() {
 					if !reachable.Contains(n) {
@@ -512,7 +291,7 @@ func (g Grammar) EliminateUnreachableProductions() Grammar {
 		}
 	}
 
-	newGrammar := Grammar{
+	newG := Grammar{
 		Terminals:    g.Terminals.Clone(),
 		NonTerminals: reachable,
 		Productions:  NewProductions(),
@@ -520,13 +299,13 @@ func (g Grammar) EliminateUnreachableProductions() Grammar {
 	}
 
 	// Only consider the reachable production rules.
-	for p := range g.AllProductions() {
+	for p := range g.Productions.All() {
 		if reachable.Contains(p.Head) {
-			newGrammar.AddProduction(p)
+			newG.Productions.Add(p)
 		}
 	}
 
-	return newGrammar
+	return newG
 }
 
 // EliminateCycles converts a context-free grammar into an equivalent cycle-free grammar.
@@ -541,13 +320,113 @@ func (g Grammar) EliminateCycles() Grammar {
 	return g.EliminateEmptyProductions().EliminateSingleProductions().EliminateUnreachableProductions()
 }
 
+// ChomskyNormalForm converts a context-free grammar into an equivalent grammar in Chomsky Normal Form.
+//
+// A grammar is in Chomsky Normal Form (CNF) if every production is either of the form A → BC or A → a,
+//
+//	where A, B, and C are non-terminal symbols, and a is a terminal symbol
+//	(with the possible exception of the empty string derived from the start symbol, S → ε).
+func (g Grammar) ChomskyNormalForm() Grammar {
+	newG := Grammar{
+		Terminals:    g.Terminals.Clone(),
+		NonTerminals: g.NonTerminals.Clone(),
+		Productions:  NewProductions(),
+		Start:        g.Start,
+	}
+
+	return newG
+}
+
 // EliminateLeftRecursion converts a context-free grammar into an equivalent grammar with no left recursion.
 //
 // A grammar is left-recursive if it has a non-terminal A such that there is a derivation A ⇒+ Aα for some string.
 // For top-down parsers, left recursion causes the parser to loop forever.
 // Many bottom-up parsers also will not accept left-recursive grammars.
+//
+// Note that the resulting non-left-recursive grammar may have ε-productions.
 func (g Grammar) EliminateLeftRecursion() Grammar {
-	return Grammar{}
+	// Define predicates for identifying left-recursive and non-left-recursive productions
+	isLeftRecursivePredicate := func(p Production) bool { return p.IsLeftRecursive() }
+	isNotLeftRecursivePredicate := func(p Production) bool { return !p.IsLeftRecursive() }
+
+	// The algorithm implemented here is guaranteed to work if the grammar has no cycles or ε-productions.
+	newG := g.EliminateCycles()
+
+	// Arrange the non-terminals in some order.
+	// The exact order does not affect the eliminition of left recursions (immediate or indirect),
+	//   but the resulting grammar can depend on the order in which non-terminals are processed.
+	_, _, nonTerms := newG.orderNonTerminals()
+
+	for i := 0; i < len(nonTerms); i++ {
+		for j := 0; j < i-1; j++ {
+			/*
+			 * Replace each production of the form Aᵢ → Aⱼγ by the productions Aᵢ → δ₁γ | δ₂γ | ... | δₖγ,
+			 * where Aⱼ → δ₁ | δ₂ | ... | δₖ are all current Aⱼ-productions.
+			 */
+
+			Ai, Aj := nonTerms[i], nonTerms[j]
+			AiProds, AjProds := newG.Productions.Get(Ai), newG.Productions.Get(Aj)
+
+			AiAjProds := AiProds.SelectMatch(func(p Production) bool {
+				return len(p.Body) > 0 && p.Body[0].Equals(Aj)
+			})
+
+			for AiAjProd := range AiAjProds.All() {
+				newG.Productions.Remove(AiAjProd)
+				for AjProd := range AjProds.All() {
+					p := Production{Ai, AjProd.Body.Concat(AiAjProd.Body[1:])}
+					newG.Productions.Add(p)
+				}
+			}
+		}
+
+		/*
+		 * Immediate left recursion can be eliminated by the following technique,
+		 * which works for any number of A-productions.
+		 *
+		 * First, group the productions as
+		 *
+		 *   A → Aα₁ | Aα₂ | ... | Aαₘ | β₁ | β₂ | ... | βₙ
+		 *
+		 * where no αᵢ is ε and no βᵢ begins with an A. Then replace A-productions by
+		 *
+		 *    A → β₁A′ | β₂A′ | ... | βₙA′
+		 *    A′ → α₁A′ | α₂A′ | ... | αₘA′ | ε
+		 */
+
+		A := nonTerms[i]
+		AProds := newG.Productions.Get(A)
+		hasLR := AProds.AnyMatch(isLeftRecursivePredicate)
+
+		if hasLR {
+			Anew, ok := newG.addNewNonTerminal(A, "′", "″", "_new")
+			if !ok {
+				panic(fmt.Sprintf("Failed to generate a new non-terminal for %s", A))
+			}
+
+			LRProds := AProds.SelectMatch(isLeftRecursivePredicate)       // Immediately Left-Recursive A-productions
+			nonLRProds := AProds.SelectMatch(isNotLeftRecursivePredicate) // Not Immediately Left-Recursive A-productions
+
+			// Remove A → Aα₁ | Aα₂ | ... | Aαₘ | β₁ | β₂ | ... | βₙ
+			newG.Productions.RemoveAll(A)
+
+			// Add A → β₁A′ | β₂A′ | ... | βₙA′
+			for nonLRProd := range nonLRProds.All() {
+				newG.Productions.Add(Production{A, nonLRProd.Body.Append(Anew)})
+			}
+
+			// Single productions of the form A → A, where α = ε, are already eliminated.
+			// Add A′ → α₁A′ | α₂A′ | ... | αₘA′ | ε
+			for LRProd := range LRProds.All() {
+				newG.Productions.Add(Production{Anew, LRProd.Body[1:].Append(Anew)})
+			}
+
+			// Add A′ → ε
+			newG.Productions.Add(Production{Anew, ε})
+		}
+	}
+
+	return newG
 }
 
 // LeftFactor converts a context-free grammar into an equivalent left-factored grammar.
@@ -556,58 +435,60 @@ func (g Grammar) EliminateLeftRecursion() Grammar {
 // When the choice between two alternative A-productions is not clear, we may be able to rewrite the productions
 // to defer the decision until enough of the input has been seen that we can make the right choice.
 func (g Grammar) LeftFactor() Grammar {
-	return Grammar{}
-}
+	newG := Grammar{
+		Terminals:    g.Terminals.Clone(),
+		NonTerminals: g.NonTerminals.Clone(),
+		Productions:  NewProductions(),
+		Start:        g.Start,
+	}
 
-// ChomskyNormalForm converts a context-free grammar into an equivalent grammar in Chomsky Normal Form.
-//
-// A grammar is in Chomsky Normal Form (CNF) if every production is either of the form A → BC or A → a,
-//
-//	where A, B, and C are non-terminal symbols, and a is a terminal symbol
-//	(with the possible exception of the empty string derived from the start symbol, S → ε).
-func (g Grammar) ChomskyNormalForm() Grammar {
-	return Grammar{}
+	return newG
 }
 
 // String returns a string representation of a context-free grammar.
 func (g Grammar) String() string {
-	var b strings.Builder
+	var b bytes.Buffer
 
 	terms := g.orderTerminals()
 	visited, unvisited, nonTerms := g.orderNonTerminals()
 
-	fmt.Fprintf(&b, "Terminal Symbols: %s\n", strings.Join(terms, " "))
-	fmt.Fprintf(&b, "Non-Terminal Symbols: %s\n", strings.Join(nonTerms, " "))
+	fmt.Fprintf(&b, "Terminal Symbols: %s\n", terms)
+	fmt.Fprintf(&b, "Non-Terminal Symbols: %s\n", nonTerms)
 	fmt.Fprintf(&b, "Start Symbol: %s\n", g.Start)
 	fmt.Fprintln(&b, "Production Rules:")
 
-	for _, n := range visited {
-		list, _ := g.Productions.Get(n)
-		prods := orderProductions(list)
-
-		for _, p := range prods {
-			fmt.Fprintf(&b, "  %s\n", p)
+	for _, head := range visited {
+		fmt.Fprintf(&b, "  %s → ", head)
+		for _, p := range g.Productions.Order(head) {
+			fmt.Fprintf(&b, "%s | ", p.Body.String())
 		}
+		b.Truncate(b.Len() - 3)
+		fmt.Fprintln(&b)
 	}
 
-	for _, n := range unvisited {
-		list, _ := g.Productions.Get(n)
-		prods := orderProductions(list)
-
-		for _, p := range prods {
-			fmt.Fprintf(&b, "  %s\n", p)
+	for _, head := range unvisited {
+		fmt.Fprintf(&b, "  %s → ", head)
+		for _, p := range g.Productions.Order(head) {
+			fmt.Fprintf(&b, "%s | ", p.Body.String())
 		}
+		b.Truncate(b.Len() - 3)
+		fmt.Fprintln(&b)
 	}
 
 	return b.String()
 }
 
-// generateNewNonTerminal generates a new non-terminal symbol by appending a list of suffixes to a given prefix.
-// It returns the first non-terminal that does not already exist in the set of non-terminals, along with a boolean indicating success.
-func (g Grammar) generateNewNonTerminal(prefix NonTerminal, suffixes ...string) (NonTerminal, bool) {
+// addNewNonTerminal generates and adds a new non-terminal symbol to the grammar.
+// It does so by appending each of the provided suffixes to the given prefix, in order,
+// until it finds a non-terminal that does not already exist in the set of non-terminals.
+//
+// The function returns the first new non-terminal added, along with a boolean indicating success.
+// If all generated non-terminals already exist, it returns an empty non-terminal and false.
+func (g Grammar) addNewNonTerminal(prefix NonTerminal, suffixes ...string) (NonTerminal, bool) {
 	for _, suffix := range suffixes {
 		nonTerm := NonTerminal(string(prefix) + suffix)
 		if !g.NonTerminals.Contains(nonTerm) {
+			g.NonTerminals.Add(nonTerm)
 			return nonTerm, true
 		}
 	}
@@ -618,14 +499,14 @@ func (g Grammar) generateNewNonTerminal(prefix NonTerminal, suffixes ...string) 
 // orderTerminals orders the unordered set of grammar terminals in a deterministic way.
 //
 // The goal of this function is to ensure a consistent and deterministic order for any given set of terminals.
-func (g Grammar) orderTerminals() []string {
-	terms := make([]string, 0)
+func (g Grammar) orderTerminals() String[Terminal] {
+	terms := make(String[Terminal], 0)
 	for t := range g.Terminals.All() {
-		terms = append(terms, t.String())
+		terms = append(terms, t)
 	}
 
 	// Sort terminals alphabetically based on the string representation of them.
-	sort.Quick[string](terms, cmpString)
+	sort.Quick[Terminal](terms, cmpTerminal)
 
 	return terms
 }
@@ -633,7 +514,7 @@ func (g Grammar) orderTerminals() []string {
 // orderTerminals orders the unordered set of grammar non-terminals in a deterministic way.
 //
 // The goal of this function is to ensure a consistent and deterministic order for any given set of non-terminals.
-func (g Grammar) orderNonTerminals() ([]NonTerminal, []NonTerminal, []string) {
+func (g Grammar) orderNonTerminals() ([]NonTerminal, []NonTerminal, String[NonTerminal]) {
 	visited := make([]NonTerminal, 0)
 	isVisited := func(n NonTerminal) bool {
 		for _, v := range visited {
@@ -651,8 +532,8 @@ func (g Grammar) orderNonTerminals() ([]NonTerminal, []NonTerminal, []string) {
 	//     If A is in visited, add all non-terminal in α to visited.
 	for updated := true; updated; {
 		updated = false
-		for _, list := range g.Productions.All() {
-			for _, p := range orderProductions(list) {
+		for head := range g.Productions.AllByHead() {
+			for _, p := range g.Productions.Order(head) {
 				if isVisited(p.Head) {
 					for _, n := range p.Body.NonTerminals() {
 						if !isVisited(n) {
@@ -676,61 +557,9 @@ func (g Grammar) orderNonTerminals() ([]NonTerminal, []NonTerminal, []string) {
 	// Sort unvisited non-terminals alphabetically based on the string representation of them.
 	sort.Quick[NonTerminal](unvisited, cmpNonTerminal)
 
-	allNonTerms := make([]string, 0)
-	for _, n := range visited {
-		allNonTerms = append(allNonTerms, n.String())
-	}
-	for _, n := range unvisited {
-		allNonTerms = append(allNonTerms, n.String())
-	}
+	allNonTerms := make(String[NonTerminal], 0)
+	allNonTerms = append(allNonTerms, visited...)
+	allNonTerms = append(allNonTerms, unvisited...)
 
 	return visited, unvisited, allNonTerms
-}
-
-// orderProductions orders an unordered set of production rules in a deterministic way.
-// This method assumes that all provided productions belong to the same head non-terminal.
-//
-// The ordering criteria are as follows:
-//
-//  1. Productions whose bodies contain more non-terminal symbols are prioritized first.
-//  2. If two productions have the same number of non-terminals, those with more terminal symbols in the body come first.
-//  3. If two productions have the same number of non-terminals and terminals, they are ordered alphabetically based on the symbols in their bodies.
-//
-// The goal of this function is to ensure a consistent and deterministic order for any given set of production rules.
-func orderProductions(set set.Set[Production]) []Production {
-	// Collect all production rules into a slice from the set iterator.
-	prods := slices.Collect(set.All())
-
-	// Sort the productions using a custom comparison function.
-	sort.Quick[Production](prods, func(lhs, rhs Production) int {
-		// First, compare based on the number of non-terminal symbols in the body.
-		lhsNonTermsLen, rhsNonTermsLen := len(lhs.Body.NonTerminals()), len(rhs.Body.NonTerminals())
-		if lhsNonTermsLen > rhsNonTermsLen {
-			return -1
-		} else if rhsNonTermsLen > lhsNonTermsLen {
-			return 1
-		}
-
-		// Next, if the number of non-terminals is the same,
-		//   compare based on the number of terminal symbols.
-		lhsTermsLen, rhsTermsLen := len(lhs.Body.Terminals()), len(rhs.Body.Terminals())
-		if lhsTermsLen > rhsTermsLen {
-			return -1
-		} else if rhsTermsLen > lhsTermsLen {
-			return 1
-		}
-
-		// Then, if the number of terminals is also the same,
-		//   compare alphabetically based on the string representation of the bodies.
-		lhsString, rhsString := lhs.String(), rhs.String()
-		if lhsString < rhsString {
-			return -1
-		} else if rhsString < lhsString {
-			return 1
-		}
-
-		return 0
-	})
-
-	return prods
 }

--- a/internal/grammar/grammar_test.go
+++ b/internal/grammar/grammar_test.go
@@ -1,10 +1,8 @@
 package grammar
 
 import (
-	"slices"
 	"testing"
 
-	"github.com/moorara/algo/set"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -99,7 +97,7 @@ var grammars = []Grammar{
 			{"E", String[Symbol]{NonTerminal("T")}},                                  // E → T
 			{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
 			{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
-			{"E", String[Symbol]{NonTerminal("T")}},                                  // T → F
+			{"T", String[Symbol]{NonTerminal("F")}},                                  // T → F
 			{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // F → ( E )
 			{"F", String[Symbol]{Terminal("id")}},                                    // F → id
 		},
@@ -133,166 +131,6 @@ var grammars = []Grammar{
 		},
 		"grammar",
 	),
-}
-
-func TestTerminal(t *testing.T) {
-	tests := []struct {
-		value string
-	}{
-		{value: "a"},
-		{value: "b"},
-		{value: "c"},
-		{value: "0"},
-		{value: "1"},
-		{value: "2"},
-		{value: "+"},
-		{value: "*"},
-		{value: "("},
-		{value: ")"},
-		{value: "id"},
-		{value: "if"},
-	}
-
-	notEqual := Terminal("🙂")
-
-	for _, tc := range tests {
-		t.Run(tc.value, func(t *testing.T) {
-			tr := Terminal(tc.value)
-			assert.Equal(t, tc.value, tr.String())
-			assert.Equal(t, tc.value, tr.Name())
-			assert.True(t, tr.Equals(Terminal(tc.value)))
-			assert.False(t, tr.Equals(NonTerminal(tc.value)))
-			assert.False(t, tr.Equals(notEqual))
-			assert.True(t, tr.IsTerminal())
-		})
-	}
-}
-
-func TestNonTerminal(t *testing.T) {
-	tests := []struct {
-		value string
-	}{
-		{value: "A"},
-		{value: "B"},
-		{value: "C"},
-		{value: "S"},
-		{value: "expr"},
-		{value: "stmt"},
-	}
-
-	notEqual := NonTerminal("🙂")
-
-	for _, tc := range tests {
-		t.Run(tc.value, func(t *testing.T) {
-			n := NonTerminal(tc.value)
-			assert.Equal(t, tc.value, n.String())
-			assert.Equal(t, tc.value, n.Name())
-			assert.True(t, n.Equals(NonTerminal(tc.value)))
-			assert.False(t, n.Equals(Terminal(tc.value)))
-			assert.False(t, n.Equals(notEqual))
-			assert.False(t, n.IsTerminal())
-		})
-	}
-}
-
-func TestString(t *testing.T) {
-	tests := []struct {
-		name                 string
-		s                    String[Symbol]
-		expectedString       string
-		expectedTerminals    String[Terminal]
-		expectedNonTerminals String[NonTerminal]
-	}{
-		{
-			name:                 "Empty",
-			s:                    ε,
-			expectedString:       "ε",
-			expectedTerminals:    String[Terminal]{},
-			expectedNonTerminals: String[NonTerminal]{},
-		},
-		{
-			name:                 "AllTerminals",
-			s:                    String[Symbol]{Terminal("a"), Terminal("b"), Terminal("c")},
-			expectedString:       "a b c",
-			expectedTerminals:    String[Terminal]{"a", "b", "c"},
-			expectedNonTerminals: String[NonTerminal]{},
-		},
-		{
-			name:                 "AllNonTerminals",
-			s:                    String[Symbol]{NonTerminal("A"), NonTerminal("B"), NonTerminal("C")},
-			expectedString:       "A B C",
-			expectedTerminals:    String[Terminal]{},
-			expectedNonTerminals: String[NonTerminal]{"A", "B", "C"},
-		},
-		{
-			name:                 "TerminalsAndNonTerminals",
-			s:                    String[Symbol]{Terminal("a"), NonTerminal("A"), Terminal("b"), NonTerminal("B"), Terminal("c")},
-			expectedString:       "a A b B c",
-			expectedTerminals:    String[Terminal]{"a", "b", "c"},
-			expectedNonTerminals: String[NonTerminal]{"A", "B"},
-		},
-	}
-
-	notEqual := String[Symbol]{Terminal("🙂"), NonTerminal("🙃")}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expectedString, tc.s.String())
-			assert.Equal(t, tc.expectedTerminals, tc.s.Terminals())
-			assert.Equal(t, tc.expectedNonTerminals, tc.s.NonTerminals())
-			assert.True(t, tc.s.Equals(tc.s))
-			assert.False(t, tc.s.Equals(notEqual))
-		})
-	}
-}
-
-func TestProduction(t *testing.T) {
-	tests := []struct {
-		name             string
-		p                Production
-		expectedString   string
-		expectedIsEmpty  bool
-		expectedIsSingle bool
-	}{
-		{
-			name:             "First",
-			p:                Production{"S", ε},
-			expectedString:   "S → ε",
-			expectedIsEmpty:  true,
-			expectedIsSingle: false,
-		},
-		{
-			name:             "Second",
-			p:                Production{"A", String[Symbol]{NonTerminal("B")}},
-			expectedString:   "A → B",
-			expectedIsEmpty:  false,
-			expectedIsSingle: true,
-		},
-		{
-			name:             "Third",
-			p:                Production{"stmt", String[Symbol]{Terminal("if"), NonTerminal("expr"), Terminal("then"), NonTerminal("stmt")}},
-			expectedString:   "stmt → if expr then stmt",
-			expectedIsEmpty:  false,
-			expectedIsSingle: false,
-		},
-	}
-
-	notEqual := Production{"😐", String[Symbol]{Terminal("🙂"), NonTerminal("🙃")}}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expectedString, tc.p.String())
-			assert.True(t, tc.p.Equals(tc.p))
-			assert.False(t, tc.p.Equals(notEqual))
-			assert.Equal(t, tc.expectedIsEmpty, tc.p.IsEmpty())
-			assert.Equal(t, tc.expectedIsSingle, tc.p.IsSingle())
-		})
-	}
-}
-
-func TestProductions(t *testing.T) {
-	prods := NewProductions()
-	assert.NotNil(t, prods)
 }
 
 func TestNew(t *testing.T) {
@@ -347,81 +185,6 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestGrammar_AddProduction(t *testing.T) {
-	tests := []struct {
-		name  string
-		g     Grammar
-		prods []Production
-	}{
-		{
-			name: "OK",
-			g: New(
-				[]Terminal{"+", "-", "*", "/", "(", ")", "id"},
-				[]NonTerminal{"E", "T", "F", "S"},
-				[]Production{},
-				"S",
-			),
-			prods: []Production{
-				{"S", String[Symbol]{NonTerminal("E")}},                                  // S → E
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("T")}}, // E → E + T
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}}, // E → E - T
-				{"E", String[Symbol]{NonTerminal("T")}},                                  // E → T
-				{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
-				{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
-				{"E", String[Symbol]{NonTerminal("T")}},                                  // T → F
-				{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // F → ( E )
-				{"F", String[Symbol]{Terminal("id")}},                                    // F → id
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			tc.g.AddProduction(tc.prods...)
-
-			for _, expectedProduction := range tc.prods {
-				list, ok := tc.g.Productions.Get(expectedProduction.Head)
-				assert.True(t, ok)
-				assert.True(t, list.Contains(expectedProduction))
-			}
-		})
-	}
-}
-
-func TestGrammar_AllProductions(t *testing.T) {
-	tests := []struct {
-		name                string
-		g                   Grammar
-		expectedProductions []Production
-	}{
-		{
-			name: "OK",
-			g:    grammars[6],
-			expectedProductions: []Production{
-				{"S", String[Symbol]{NonTerminal("E")}},                                  // S → E
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("T")}}, // E → E + T
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}}, // E → E - T
-				{"E", String[Symbol]{NonTerminal("T")}},                                  // E → T
-				{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
-				{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
-				{"E", String[Symbol]{NonTerminal("T")}},                                  // T → F
-				{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // F → ( E )
-				{"F", String[Symbol]{Terminal("id")}},                                    // F → id
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			prods := slices.Collect[Production](tc.g.AllProductions())
-
-			for _, expectedProduction := range tc.expectedProductions {
-				assert.Contains(t, prods, expectedProduction)
-			}
-		})
-	}
-}
-
 func TestGrammar_Verify(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -436,7 +199,7 @@ func TestGrammar_Verify(t *testing.T) {
 				[]Production{},
 				"S",
 			),
-			expectedError: "start symbol \"S\" not in the set of non-terminal symbols\nno production rule for start symbol \"S\"",
+			expectedError: "start symbol S not in the set of non-terminal symbols\nno production rule for start symbol S",
 		},
 		{
 			name: "StartSymbolHasNoProduction",
@@ -446,7 +209,7 @@ func TestGrammar_Verify(t *testing.T) {
 				[]Production{},
 				"S",
 			),
-			expectedError: "no production rule for start symbol \"S\"\nno production rule for non-terminal symbol \"S\"",
+			expectedError: "no production rule for start symbol S\nno production rule for non-terminal symbol S",
 		},
 		{
 			name: "NonTerminalHasNoProduction",
@@ -458,7 +221,7 @@ func TestGrammar_Verify(t *testing.T) {
 				},
 				"S",
 			),
-			expectedError: "no production rule for non-terminal symbol \"A\"",
+			expectedError: "no production rule for non-terminal symbol A",
 		},
 		{
 			name: "ProductionHeadNotDeclared",
@@ -472,7 +235,7 @@ func TestGrammar_Verify(t *testing.T) {
 				},
 				"S",
 			),
-			expectedError: "production head \"B\" not in the set of non-terminal symbols",
+			expectedError: "production head B not in the set of non-terminal symbols",
 		},
 		{
 			name: "TerminalNotDeclared",
@@ -500,7 +263,7 @@ func TestGrammar_Verify(t *testing.T) {
 				},
 				"S",
 			),
-			expectedError: "non-terminal symbol \"C\" not in the set of non-terminal symbols",
+			expectedError: "non-terminal symbol C not in the set of non-terminal symbols",
 		},
 		{
 			name: "Valid",
@@ -650,7 +413,7 @@ func TestGrammar_Equals(t *testing.T) {
 					{"E", String[Symbol]{NonTerminal("T")}},                                  // E → T
 					{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
 					{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
-					{"E", String[Symbol]{NonTerminal("T")}},                                  // T → F
+					{"T", String[Symbol]{NonTerminal("F")}},                                  // T → F
 					{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // F → ( E )
 					{"F", String[Symbol]{Terminal("id")}},                                    // F → id
 				},
@@ -662,7 +425,7 @@ func TestGrammar_Equals(t *testing.T) {
 				[]Production{
 					{"F", String[Symbol]{Terminal("id")}},                                    // F → id
 					{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // F → ( E )
-					{"E", String[Symbol]{NonTerminal("T")}},                                  // T → F
+					{"T", String[Symbol]{NonTerminal("F")}},                                  // T → F
 					{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
 					{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
 					{"E", String[Symbol]{NonTerminal("T")}},                                  // E → T
@@ -973,12 +736,18 @@ func TestGrammar_EliminateSingleProductions(t *testing.T) {
 					{"S", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}}, // S → E - T
 					{"S", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // S → T * F
 					{"S", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // S → T / F
+					{"S", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // S → ( E )
+					{"S", String[Symbol]{Terminal("id")}},                                    // S → id
 					{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("T")}}, // E → E + T
 					{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}}, // E → E - T
 					{"E", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // E → T * F
 					{"E", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // E → T / F
+					{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // E → ( E )
+					{"E", String[Symbol]{Terminal("id")}},                                    // E → id
 					{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
 					{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
+					{"T", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // T → ( E )
+					{"T", String[Symbol]{Terminal("id")}},                                    // T → id
 					{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // F → ( E )
 					{"F", String[Symbol]{Terminal("id")}},                                    // F → id
 				},
@@ -1238,12 +1007,18 @@ func TestGrammar_EliminateCycles(t *testing.T) {
 					{"S", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}}, // S → E - T
 					{"S", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // S → T * F
 					{"S", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // S → T / F
+					{"S", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // S → ( E )
+					{"S", String[Symbol]{Terminal("id")}},                                    // S → id
 					{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("T")}}, // E → E + T
 					{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}}, // E → E - T
 					{"E", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // E → T * F
 					{"E", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // E → T / F
+					{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // E → ( E )
+					{"E", String[Symbol]{Terminal("id")}},                                    // E → id
 					{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
 					{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
+					{"T", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // T → ( E )
+					{"T", String[Symbol]{Terminal("id")}},                                    // T → id
 					{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // F → ( E )
 					{"F", String[Symbol]{Terminal("id")}},                                    // F → id
 				},
@@ -1291,17 +1066,223 @@ func TestGrammar_EliminateCycles(t *testing.T) {
 	}
 }
 
-func TestGrammar_EliminateLeftRecursion(t *testing.T) {
+func TestGrammar_ChomskyNormalForm(t *testing.T) {
 	tests := []struct {
 		name            string
 		g               Grammar
-		expectedGrammar string
+		expectedGrammar Grammar
 	}{}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := tc.g.ChomskyNormalForm()
+			assert.True(t, g.Equals(tc.expectedGrammar))
+		})
+	}
+}
+
+func TestGrammar_EliminateLeftRecursion(t *testing.T) {
+	tests := []struct {
+		name            string
+		g               Grammar
+		expectedGrammar Grammar
+	}{
+		{
+			name: "1st",
+			g:    grammars[0],
+			expectedGrammar: New(
+				[]Terminal{"0", "1"},
+				[]NonTerminal{"S′", "X", "Y"},
+				[]Production{
+					{"S′", String[Symbol]{NonTerminal("X"), NonTerminal("Y"), NonTerminal("X")}}, // S′ → XYX
+					{"S′", String[Symbol]{NonTerminal("X"), NonTerminal("X")}},                   // S′ → XX
+					{"S′", String[Symbol]{NonTerminal("X"), NonTerminal("Y")}},                   // S′ → XY
+					{"S′", String[Symbol]{NonTerminal("Y"), NonTerminal("X")}},                   // S′ → YX
+					{"S′", String[Symbol]{Terminal("0"), NonTerminal("X")}},                      // S′ → 0X
+					{"S′", String[Symbol]{Terminal("1"), NonTerminal("Y")}},                      // S′ → 1Y
+					{"S′", String[Symbol]{Terminal("0")}},                                        // S′ → 0
+					{"S′", String[Symbol]{Terminal("1")}},                                        // S′ → 1
+					{"S′", ε},                                                                    // S′ → ε
+					{"X", String[Symbol]{Terminal("0"), NonTerminal("X")}},                       // X → 0X
+					{"X", String[Symbol]{Terminal("0")}},                                         // X → 0
+					{"Y", String[Symbol]{Terminal("1"), NonTerminal("Y")}},                       // Y → 1Y
+					{"Y", String[Symbol]{Terminal("1")}},                                         // Y → 1
+				},
+				"S′",
+			),
+		},
+		{
+			name: "2nd",
+			g:    grammars[1],
+			expectedGrammar: New(
+				[]Terminal{"a", "b"},
+				[]NonTerminal{"S′", "S"},
+				[]Production{
+					{"S′", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b"), NonTerminal("S")}}, // S′ → aSbS
+					{"S′", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a"), NonTerminal("S")}}, // S′ → bSaS
+					{"S′", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b")}},                   // S′ → aSb
+					{"S′", String[Symbol]{Terminal("a"), Terminal("b"), NonTerminal("S")}},                   // S′ → abS
+					{"S′", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a")}},                   // S′ → bSa
+					{"S′", String[Symbol]{Terminal("b"), Terminal("a"), NonTerminal("S")}},                   // S′ → baS
+					{"S′", String[Symbol]{Terminal("a"), Terminal("b")}},                                     // S′ → ab
+					{"S′", String[Symbol]{Terminal("b"), Terminal("a")}},                                     // S′ → ba
+					{"S′", ε}, // S′ → ε
+					{"S", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b"), NonTerminal("S")}}, // S → aSbS
+					{"S", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a"), NonTerminal("S")}}, // S → bSaS
+					{"S", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b")}},                   // S → aSb
+					{"S", String[Symbol]{Terminal("a"), Terminal("b"), NonTerminal("S")}},                   // S → abS
+					{"S", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a")}},                   // S → bSa
+					{"S", String[Symbol]{Terminal("b"), Terminal("a"), NonTerminal("S")}},                   // S → baS
+					{"S", String[Symbol]{Terminal("a"), Terminal("b")}},                                     // S → ab
+					{"S", String[Symbol]{Terminal("b"), Terminal("a")}},                                     // S → ba
+				},
+				"S′",
+			),
+		},
+		{
+			name: "3rd",
+			g:    grammars[2],
+			expectedGrammar: New(
+				[]Terminal{"a", "b"},
+				[]NonTerminal{"S", "A", "B"},
+				[]Production{
+					{"S", String[Symbol]{Terminal("a"), NonTerminal("B"), Terminal("a")}}, // S → aBa
+					{"S", String[Symbol]{NonTerminal("A"), Terminal("b")}},                // S → Ab
+					{"S", String[Symbol]{Terminal("a"), Terminal("a")}},                   // S → aa
+					{"S", String[Symbol]{Terminal("a")}},                                  // S → a
+					{"S", String[Symbol]{Terminal("b")}},                                  // S → b
+					{"A", String[Symbol]{Terminal("b")}},                                  // A → b
+					{"B", String[Symbol]{Terminal("b")}},                                  // B → b
+				},
+				"S",
+			),
+		},
+		{
+			name: "4th",
+			g:    grammars[3],
+			expectedGrammar: New(
+				[]Terminal{"b", "c", "d", "s"},
+				[]NonTerminal{"S"},
+				[]Production{
+					{"S", String[Symbol]{Terminal("b")}}, // S → b
+					{"S", String[Symbol]{Terminal("d")}}, // S → d
+					{"S", String[Symbol]{Terminal("s")}}, // S → s
+				},
+				"S",
+			),
+		},
+		{
+			name: "5th",
+			g:    grammars[4],
+			expectedGrammar: New(
+				[]Terminal{"a", "b", "c", "d"},
+				[]NonTerminal{"S", "A", "B"},
+				[]Production{
+					{"S", String[Symbol]{NonTerminal("A"), NonTerminal("B")}}, // S → AB
+					{"A", String[Symbol]{Terminal("a"), NonTerminal("A")}},    // A → aA
+					{"A", String[Symbol]{Terminal("a")}},                      // A → a
+					{"B", String[Symbol]{Terminal("b"), NonTerminal("B")}},    // B → bB
+					{"B", String[Symbol]{Terminal("b")}},                      // B → b
+				},
+				"S",
+			),
+		},
+		{
+			name: "6th",
+			g:    grammars[5],
+			expectedGrammar: New(
+				[]Terminal{"+", "-", "*", "/", "(", ")", "id"},
+				[]NonTerminal{"S", "E", "E′"},
+				[]Production{
+					{"S", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}},                 // S → E + E
+					{"S", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}},                 // S → E - E
+					{"S", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}},                 // S → E * E
+					{"S", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}},                 // S → E / E
+					{"S", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},                    // S → ( E )
+					{"S", String[Symbol]{Terminal("-"), NonTerminal("E")}},                                   // S → - E
+					{"S", String[Symbol]{Terminal("id")}},                                                    // S → id
+					{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")"), NonTerminal("E′")}}, // E → ( E ) E′
+					{"E", String[Symbol]{Terminal("-"), NonTerminal("E"), NonTerminal("E′")}},                // E → - E E′
+					{"E", String[Symbol]{Terminal("id"), NonTerminal("E′")}},                                 // E → id E′
+					{"E′", String[Symbol]{Terminal("+"), NonTerminal("E"), NonTerminal("E′")}},               // E′ → + E E′
+					{"E′", String[Symbol]{Terminal("-"), NonTerminal("E"), NonTerminal("E′")}},               // E′ → - E E′
+					{"E′", String[Symbol]{Terminal("*"), NonTerminal("E"), NonTerminal("E′")}},               // E′ → * E E′
+					{"E′", String[Symbol]{Terminal("/"), NonTerminal("E"), NonTerminal("E′")}},               // E′ → / E E′
+					{"E′", ε}, // E′ → ε
+				},
+				"S",
+			),
+		},
+		{
+			name: "7th",
+			g:    grammars[6],
+			expectedGrammar: New(
+				[]Terminal{"+", "-", "*", "/", "(", ")", "id"},
+				[]NonTerminal{"S", "E", "E′", "T", "T′", "F"},
+				[]Production{
+					{"S", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("T")}},                    // S → E + T
+					{"S", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}},                    // S → E - T
+					{"S", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}},                    // S → T * F
+					{"S", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}},                    // S → T / F
+					{"S", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},                       // S → ( E )
+					{"S", String[Symbol]{Terminal("id")}},                                                       // S → id
+					{"E", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F"), NonTerminal("E′")}}, // E → T * F E′
+					{"E", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F"), NonTerminal("E′")}}, // E → T / F E′
+					{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")"), NonTerminal("E′")}},    // E → ( E ) E′
+					{"E", String[Symbol]{Terminal("id"), NonTerminal("E′")}},                                    // E → id E′
+					{"E′", String[Symbol]{Terminal("+"), NonTerminal("T"), NonTerminal("E′")}},                  // E′ → + T E′
+					{"E′", String[Symbol]{Terminal("-"), NonTerminal("T"), NonTerminal("E′")}},                  // E′ → - T E′
+					{"E′", ε}, // E′ → ε
+					{"T", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")"), NonTerminal("T′")}}, // T → ( E ) T′
+					{"T", String[Symbol]{Terminal("id"), NonTerminal("T′")}},                                 // T → id T′
+					{"T′", String[Symbol]{Terminal("*"), NonTerminal("F"), NonTerminal("T′")}},               // T′ → * F T′
+					{"T′", String[Symbol]{Terminal("/"), NonTerminal("F"), NonTerminal("T′")}},               // T′ → / F T′
+					{"T′", ε}, // T′ → ε
+					{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}}, // F → ( E )
+					{"F", String[Symbol]{Terminal("id")}},                                 // F → id
+				},
+				"S",
+			),
+		},
+		{
+			name: "8th",
+			g:    grammars[7],
+			expectedGrammar: New(
+				[]Terminal{"=", "|", "(", ")", "[", "]", "{", "}", "{{", "}}", "GRAMMAR", "IDENT", "TOKEN", "STRING", "REGEX"},
+				[]NonTerminal{"grammar", "name", "decls", "decls′", "decl", "lhs", "rhs", "rhs′"},
+				[]Production{
+					{"grammar", String[Symbol]{NonTerminal("name"), NonTerminal("decls")}},                                  // grammar → name decls
+					{"grammar", String[Symbol]{Terminal("GRAMMAR"), Terminal("IDENT")}},                                     // grammar → GRAMMAR IDENT
+					{"name", String[Symbol]{Terminal("GRAMMAR"), Terminal("IDENT")}},                                        // name → GRAMMAR IDENT
+					{"decls", String[Symbol]{NonTerminal("lhs"), Terminal("="), NonTerminal("rhs"), NonTerminal("decls′")}}, // decls → lhs "=" rhs decls′
+					{"decls", String[Symbol]{Terminal("TOKEN"), Terminal("="), Terminal("REGEX"), NonTerminal("decls′")}},   // decls → TOKEN "=" REGEX decls′
+					{"decls", String[Symbol]{Terminal("TOKEN"), Terminal("="), Terminal("STRING"), NonTerminal("decls′")}},  // decls → TOKEN "=" STRING decls′
+					{"decls′", String[Symbol]{NonTerminal("decl"), NonTerminal("decls′")}},                                  // decls′ → decl decls′
+					{"decls′", ε}, // decls′ → ε
+					{"decl", String[Symbol]{Terminal("IDENT"), Terminal("="), NonTerminal("rhs")}},                   // decl → IDENT "=" rhs
+					{"decl", String[Symbol]{Terminal("TOKEN"), Terminal("="), Terminal("REGEX")}},                    // decl → TOKEN "=" REGEX
+					{"decl", String[Symbol]{Terminal("TOKEN"), Terminal("="), Terminal("STRING")}},                   // decl → TOKEN "=" STRING
+					{"lhs", String[Symbol]{Terminal("IDENT")}},                                                       // lhs → IDENT
+					{"rhs", String[Symbol]{Terminal("("), NonTerminal("rhs"), Terminal(")"), NonTerminal("rhs′")}},   // rhs → "(" rhs ")" rhs′
+					{"rhs", String[Symbol]{Terminal("["), NonTerminal("rhs"), Terminal("]"), NonTerminal("rhs′")}},   // rhs → "[" rhs "]" rhs′
+					{"rhs", String[Symbol]{Terminal("{"), NonTerminal("rhs"), Terminal("}"), NonTerminal("rhs′")}},   // rhs → "{" rhs "}" rhs′
+					{"rhs", String[Symbol]{Terminal("{{"), NonTerminal("rhs"), Terminal("}}"), NonTerminal("rhs′")}}, // rhs → "{{" rhs "}}" rhs′
+					{"rhs", String[Symbol]{Terminal("IDENT"), NonTerminal("rhs′")}},                                  // rhs → IDENT rhs′
+					{"rhs", String[Symbol]{Terminal("TOKEN"), NonTerminal("rhs′")}},                                  // rhs → TOKEN rhs′
+					{"rhs", String[Symbol]{Terminal("STRING"), NonTerminal("rhs′")}},                                 // rhs → STRING rhs′
+					{"rhs′", String[Symbol]{NonTerminal("rhs"), NonTerminal("rhs′")}},                                // rhs′ → rhs rhs′
+					{"rhs′", String[Symbol]{Terminal("|"), NonTerminal("rhs"), NonTerminal("rhs′")}},                 // rhs′ → "|" rhs rhs′
+					{"rhs′", ε}, // rhs′ → ε
+				},
+				"grammar",
+			),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			g := tc.g.EliminateLeftRecursion()
-			assert.Equal(t, tc.expectedGrammar, g.String())
+			assert.True(t, g.Equals(tc.expectedGrammar))
 		})
 	}
 }
@@ -1310,28 +1291,13 @@ func TestGrammar_LeftFactor(t *testing.T) {
 	tests := []struct {
 		name            string
 		g               Grammar
-		expectedGrammar string
+		expectedGrammar Grammar
 	}{}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := tc.g.LeftFactor()
-			assert.Equal(t, tc.expectedGrammar, g.String())
-		})
-	}
-}
-
-func TestGrammar_ChomskyNormalForm(t *testing.T) {
-	tests := []struct {
-		name            string
-		g               Grammar
-		expectedGrammar string
-	}{}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			g := tc.g.ChomskyNormalForm()
-			assert.Equal(t, tc.expectedGrammar, g.String())
+			assert.True(t, g.Equals(tc.expectedGrammar))
 		})
 	}
 }
@@ -1345,42 +1311,42 @@ func TestGrammar_String(t *testing.T) {
 		{
 			name:           "1st",
 			g:              grammars[0],
-			expectedString: "Terminal Symbols: 0 1\nNon-Terminal Symbols: S X Y\nStart Symbol: S\nProduction Rules:\n  S → X Y X\n  X → 0 X\n  X → ε\n  Y → 1 Y\n  Y → ε\n",
+			expectedString: "Terminal Symbols: \"0\" \"1\"\nNon-Terminal Symbols: S X Y\nStart Symbol: S\nProduction Rules:\n  S → X Y X\n  X → \"0\" X | ε\n  Y → \"1\" Y | ε\n",
 		},
 		{
 			name:           "2nd",
 			g:              grammars[1],
-			expectedString: "Terminal Symbols: a b\nNon-Terminal Symbols: S\nStart Symbol: S\nProduction Rules:\n  S → a S b S\n  S → b S a S\n  S → ε\n",
+			expectedString: "Terminal Symbols: \"a\" \"b\"\nNon-Terminal Symbols: S\nStart Symbol: S\nProduction Rules:\n  S → \"a\" S \"b\" S | \"b\" S \"a\" S | ε\n",
 		},
 		{
 			name:           "3rd",
 			g:              grammars[2],
-			expectedString: "Terminal Symbols: a b\nNon-Terminal Symbols: S B A\nStart Symbol: S\nProduction Rules:\n  S → a B a\n  S → A b\n  S → a\n  B → A\n  B → b\n  A → b\n  A → ε\n",
+			expectedString: "Terminal Symbols: \"a\" \"b\"\nNon-Terminal Symbols: S B A\nStart Symbol: S\nProduction Rules:\n  S → \"a\" B \"a\" | A \"b\" | \"a\"\n  B → A | \"b\"\n  A → \"b\" | ε\n",
 		},
 		{
 			name:           "4th",
 			g:              grammars[3],
-			expectedString: "Terminal Symbols: b c d s\nNon-Terminal Symbols: S A B C D\nStart Symbol: S\nProduction Rules:\n  S → A\n  S → s\n  A → B\n  B → C\n  B → b\n  C → D\n  D → d\n",
+			expectedString: "Terminal Symbols: \"b\" \"c\" \"d\" \"s\"\nNon-Terminal Symbols: S A B C D\nStart Symbol: S\nProduction Rules:\n  S → A | \"s\"\n  A → B\n  B → C | \"b\"\n  C → D\n  D → \"d\"\n",
 		},
 		{
 			name:           "5th",
 			g:              grammars[4],
-			expectedString: "Terminal Symbols: a b c d\nNon-Terminal Symbols: S A B C D\nStart Symbol: S\nProduction Rules:\n  S → A B\n  A → a A\n  A → a\n  B → b B\n  B → b\n  C → c C\n  C → c\n  D → d\n",
+			expectedString: "Terminal Symbols: \"a\" \"b\" \"c\" \"d\"\nNon-Terminal Symbols: S A B C D\nStart Symbol: S\nProduction Rules:\n  S → A B\n  A → \"a\" A | \"a\"\n  B → \"b\" B | \"b\"\n  C → \"c\" C | \"c\"\n  D → \"d\"\n",
 		},
 		{
 			name:           "6th",
 			g:              grammars[5],
-			expectedString: "Terminal Symbols: ( ) * + - / id\nNon-Terminal Symbols: S E\nStart Symbol: S\nProduction Rules:\n  S → E\n  E → E * E\n  E → E + E\n  E → E - E\n  E → E / E\n  E → ( E )\n  E → - E\n  E → id\n",
+			expectedString: "Terminal Symbols: \"(\" \")\" \"*\" \"+\" \"-\" \"/\" \"id\"\nNon-Terminal Symbols: S E\nStart Symbol: S\nProduction Rules:\n  S → E\n  E → E \"*\" E | E \"+\" E | E \"-\" E | E \"/\" E | \"(\" E \")\" | \"-\" E | \"id\"\n",
 		},
 		{
 			name:           "7th",
 			g:              grammars[6],
-			expectedString: "Terminal Symbols: ( ) * + - / id\nNon-Terminal Symbols: S E T F\nStart Symbol: S\nProduction Rules:\n  S → E\n  E → E + T\n  E → E - T\n  E → T\n  T → T * F\n  T → T / F\n  F → ( E )\n  F → id\n",
+			expectedString: "Terminal Symbols: \"(\" \")\" \"*\" \"+\" \"-\" \"/\" \"id\"\nNon-Terminal Symbols: S E T F\nStart Symbol: S\nProduction Rules:\n  S → E\n  E → E \"+\" T | E \"-\" T | T\n  T → T \"*\" F | T \"/\" F | F\n  F → \"(\" E \")\" | \"id\"\n",
 		},
 		{
 			name:           "8th",
 			g:              grammars[7],
-			expectedString: "Terminal Symbols: ( ) = GRAMMAR IDENT REGEX STRING TOKEN [ ] { {{ | } }}\nNon-Terminal Symbols: grammar name decls decl rule token lhs rhs nonterm term\nStart Symbol: grammar\nProduction Rules:\n  grammar → name decls\n  name → GRAMMAR IDENT\n  decls → decls decl\n  decls → ε\n  decl → rule\n  decl → token\n  rule → lhs = rhs\n  token → TOKEN = REGEX\n  token → TOKEN = STRING\n  lhs → nonterm\n  rhs → rhs | rhs\n  rhs → rhs rhs\n  rhs → ( rhs )\n  rhs → [ rhs ]\n  rhs → { rhs }\n  rhs → {{ rhs }}\n  rhs → nonterm\n  rhs → term\n  nonterm → IDENT\n  term → STRING\n  term → TOKEN\n",
+			expectedString: "Terminal Symbols: \"(\" \")\" \"=\" \"GRAMMAR\" \"IDENT\" \"REGEX\" \"STRING\" \"TOKEN\" \"[\" \"]\" \"{\" \"{{\" \"|\" \"}\" \"}}\"\nNon-Terminal Symbols: grammar name decls decl rule token lhs rhs nonterm term\nStart Symbol: grammar\nProduction Rules:\n  grammar → name decls\n  name → \"GRAMMAR\" \"IDENT\"\n  decls → decls decl | ε\n  decl → rule | token\n  rule → lhs \"=\" rhs\n  token → \"TOKEN\" \"=\" \"REGEX\" | \"TOKEN\" \"=\" \"STRING\"\n  lhs → nonterm\n  rhs → rhs \"|\" rhs | rhs rhs | \"(\" rhs \")\" | \"[\" rhs \"]\" | \"{\" rhs \"}\" | \"{{\" rhs \"}}\" | nonterm | term\n  nonterm → \"IDENT\"\n  term → \"STRING\" | \"TOKEN\"\n",
 		},
 	}
 
@@ -1391,7 +1357,7 @@ func TestGrammar_String(t *testing.T) {
 	}
 }
 
-func TestGrammar_generateNewNonTerminal(t *testing.T) {
+func TestGrammar_addNewNonTerminal(t *testing.T) {
 	tests := []struct {
 		name                string
 		g                   Grammar
@@ -1420,7 +1386,7 @@ func TestGrammar_generateNewNonTerminal(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			nonTerm, ok := tc.g.generateNewNonTerminal(tc.prefix, tc.suffixes...)
+			nonTerm, ok := tc.g.addNewNonTerminal(tc.prefix, tc.suffixes...)
 			assert.Equal(t, tc.expectedOK, ok)
 			assert.Equal(t, tc.expectedNonTerminal, nonTerm)
 		})
@@ -1431,12 +1397,12 @@ func TestGrammar_orderTerminals(t *testing.T) {
 	tests := []struct {
 		name              string
 		g                 Grammar
-		expectedTerminals []string
+		expectedTerminals String[Terminal]
 	}{
 		{
 			name:              "OK",
 			g:                 grammars[4],
-			expectedTerminals: []string{"a", "b", "c", "d"},
+			expectedTerminals: String[Terminal]{"a", "b", "c", "d"},
 		},
 	}
 
@@ -1454,14 +1420,14 @@ func TestGrammar_orderNonTerminals(t *testing.T) {
 		g                    Grammar
 		expectedVisited      []NonTerminal
 		expectedUnvisited    []NonTerminal
-		expectedNonTerminals []string
+		expectedNonTerminals String[NonTerminal]
 	}{
 		{
 			name:                 "OK",
 			g:                    grammars[4],
 			expectedVisited:      []NonTerminal{"S", "A", "B"},
 			expectedUnvisited:    []NonTerminal{"C", "D"},
-			expectedNonTerminals: []string{"S", "A", "B", "C", "D"},
+			expectedNonTerminals: String[NonTerminal]{"S", "A", "B", "C", "D"},
 		},
 	}
 
@@ -1471,47 +1437,6 @@ func TestGrammar_orderNonTerminals(t *testing.T) {
 			assert.Equal(t, tc.expectedVisited, visited)
 			assert.Equal(t, tc.expectedUnvisited, unvisited)
 			assert.Equal(t, tc.expectedNonTerminals, nonTerms)
-		})
-	}
-}
-
-func TestGrammar_orderProductions(t *testing.T) {
-	s := set.New[Production](eqProduction)
-	s.Add(
-		Production{"E", String[Symbol]{Terminal("id")}},                                    // E → id
-		Production{"E", String[Symbol]{Terminal("-"), NonTerminal("E")}},                   // E → - E
-		Production{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // E → ( E )
-		Production{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}}, // E → E + E
-		Production{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}}, // E → E - E
-		Production{"E", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}}, // E → E * E
-		Production{"E", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}}, // E → E / E
-	)
-
-	tests := []struct {
-		name                string
-		g                   Grammar
-		set                 set.Set[Production]
-		expectedProductions []Production
-	}{
-		{
-			name: "OK",
-			set:  s,
-			expectedProductions: []Production{
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}}, // E → E * E
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}}, // E → E + E
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}}, // E → E - E
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}}, // E → E / E
-				{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // E → ( E )
-				{"E", String[Symbol]{Terminal("-"), NonTerminal("E")}},                   // E → - E
-				{"E", String[Symbol]{Terminal("id")}},                                    // E → id
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			prods := orderProductions(tc.set)
-			assert.Equal(t, tc.expectedProductions, prods)
 		})
 	}
 }

--- a/internal/grammar/production.go
+++ b/internal/grammar/production.go
@@ -1,0 +1,274 @@
+package grammar
+
+import (
+	"bytes"
+	"fmt"
+	"iter"
+	"slices"
+
+	"github.com/moorara/algo/generic"
+	"github.com/moorara/algo/set"
+	"github.com/moorara/algo/sort"
+	"github.com/moorara/algo/symboltable"
+)
+
+var (
+	eqProduction = func(lhs, rhs Production) bool {
+		return lhs.Equals(rhs)
+	}
+
+	eqProductionSet = func(lhs, rhs set.Set[Production]) bool {
+		return lhs.Equals(rhs)
+	}
+)
+
+// Production represents a production rule.
+// The productions of a grammar determine how the terminals and non-terminals can be combined to form strings.
+type Production struct {
+	// Head or left side defines some of the strings denoted by the non-terminal symbol.
+	Head NonTerminal
+	// Body or right side describes one way in which strings of the non-terminal at the head can be constructed.
+	Body String[Symbol]
+}
+
+// String returns a string representation of a production rule.
+func (p Production) String() string {
+	return fmt.Sprintf("%s → %s", p.Head, p.Body)
+}
+
+// Equals determines whether or not two production rules are the same.
+func (p Production) Equals(rhs Production) bool {
+	return p.Head.Equals(rhs.Head) && p.Body.Equals(rhs.Body)
+}
+
+// IsEmpty determines whether or not a production rule is an empty production (ε-production).
+//
+// An empty production (ε-production) is any production of the form A → ε.
+func (p Production) IsEmpty() bool {
+	return len(p.Body) == 0
+}
+
+// IsSingle determines whether or not a production rule is a single production (unit production).
+//
+// A single production (unit production) is a production whose body is a single non-terminal (A → B).
+func (p Production) IsSingle() bool {
+	return len(p.Body) == 1 && !p.Body[0].IsTerminal()
+}
+
+// IsLeftRecursive determines whether or not a production rule is left recursive (immediate left recursive).
+//
+// A left recursive production is a production rule of the form of A → Aα
+func (p Production) IsLeftRecursive() bool {
+	return len(p.Body) > 0 && p.Body[0].Equals(p.Head)
+}
+
+// Productions is the interface for a set of production rules in a grammar.
+type Productions interface {
+	fmt.Stringer
+	generic.Equaler[Productions]
+
+	Clone() Productions
+	Add(...Production)
+	Remove(...Production)
+	RemoveAll(...NonTerminal)
+	Get(NonTerminal) set.Set[Production]
+	Order(NonTerminal) []Production
+	All() iter.Seq[Production]
+	AllByHead() iter.Seq2[NonTerminal, set.Set[Production]]
+	AnyMatch(generic.Predicate1[Production]) bool
+	AllMatch(generic.Predicate1[Production]) bool
+}
+
+// productions implements the Productions interface.
+type productions struct {
+	table symboltable.SymbolTable[NonTerminal, set.Set[Production]]
+}
+
+// NewProductions creates a new instance of the Productions.
+func NewProductions() Productions {
+	return &productions{
+		table: symboltable.NewQuadraticHashTable[NonTerminal, set.Set[Production]](
+			hashNonTerminal,
+			eqNonTerminal,
+			eqProductionSet,
+			symboltable.HashOpts{},
+		),
+	}
+}
+
+// String returns a string representation of production rules.
+func (p *productions) String() string {
+	var b bytes.Buffer
+
+	for head := range p.table.All() {
+		fmt.Fprintf(&b, "%s → ", head)
+		for _, q := range p.Order(head) {
+			fmt.Fprintf(&b, "%s | ", q.Body.String())
+		}
+		b.Truncate(b.Len() - 3)
+		fmt.Fprintln(&b)
+	}
+
+	return b.String()
+}
+
+// Equals determines whether or not two sets of production rules are the same.
+func (p *productions) Equals(rhs Productions) bool {
+	q, ok := rhs.(*productions)
+	return ok && p.table.Equals(q.table)
+}
+
+// Clone returns a deep copy of the production rules, ensuring the clone is independent of the original.
+func (p *productions) Clone() Productions {
+	newP := NewProductions()
+	for q := range p.All() {
+		newP.Add(q)
+	}
+
+	return newP
+}
+
+// Add adds a new production rule.
+func (p *productions) Add(ps ...Production) {
+	for _, q := range ps {
+		if _, ok := p.table.Get(q.Head); !ok {
+			p.table.Put(q.Head, set.New[Production](eqProduction))
+		}
+
+		list, _ := p.table.Get(q.Head)
+		list.Add(q)
+	}
+}
+
+// Remove removes a production rule.
+func (p *productions) Remove(ps ...Production) {
+	for _, q := range ps {
+		if list, ok := p.table.Get(q.Head); ok {
+			list.Remove(q)
+			if list.IsEmpty() {
+				p.table.Delete(q.Head)
+			}
+		}
+	}
+}
+
+// RemoveAll removes all production rules with the specified head non-terminal.
+func (p *productions) RemoveAll(heads ...NonTerminal) {
+	for _, head := range heads {
+		p.table.Delete(head)
+	}
+}
+
+// Get finds and returns a production rule by its head non-terminal symbol.
+// It returns nil if no production rules are found for the specified head.
+func (p *productions) Get(head NonTerminal) set.Set[Production] {
+	list, ok := p.table.Get(head)
+	if !ok {
+		return nil
+	}
+
+	return list
+}
+
+// Order orders an unordered set of production rules with the same head non-terminal in a deterministic way.
+//
+// The ordering criteria are as follows:
+//
+//  1. Productions whose bodies contain more non-terminal symbols are prioritized first.
+//  2. If two productions have the same number of non-terminals, those with more terminal symbols in the body come first.
+//  3. If two productions have the same number of non-terminals and terminals, they are ordered alphabetically based on the symbols in their bodies.
+//
+// The goal of this function is to ensure a consistent and deterministic order for any given set of production rules.
+func (p *productions) Order(head NonTerminal) []Production {
+	// Collect all production rules into a slice from the set iterator.
+	prods := slices.Collect(p.Get(head).All())
+
+	// Sort the productions using a custom comparison function.
+	sort.Quick[Production](prods, func(lhs, rhs Production) int {
+		// First, compare based on the number of non-terminal symbols in the body.
+		lhsNonTermsLen, rhsNonTermsLen := len(lhs.Body.NonTerminals()), len(rhs.Body.NonTerminals())
+		if lhsNonTermsLen > rhsNonTermsLen {
+			return -1
+		} else if rhsNonTermsLen > lhsNonTermsLen {
+			return 1
+		}
+
+		// Next, if the number of non-terminals is the same,
+		//   compare based on the number of terminal symbols.
+		lhsTermsLen, rhsTermsLen := len(lhs.Body.Terminals()), len(rhs.Body.Terminals())
+		if lhsTermsLen > rhsTermsLen {
+			return -1
+		} else if rhsTermsLen > lhsTermsLen {
+			return 1
+		}
+
+		// Then, if the number of terminals is also the same,
+		//   compare alphabetically based on the string representation of the bodies.
+		lhsString, rhsString := lhs.String(), rhs.String()
+		if lhsString < rhsString {
+			return -1
+		} else if rhsString < lhsString {
+			return 1
+		}
+
+		return 0
+	})
+
+	return prods
+}
+
+// All returns an iterator sequence containing all production rules.
+func (p *productions) All() iter.Seq[Production] {
+	return func(yield func(Production) bool) {
+		for _, list := range p.table.All() {
+			for q := range list.All() {
+				if !yield(q) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// AllByHead returns an iterator sequence sequence of pairs,
+// where each pair consists of a head non-terminal and its associated set of production rules.
+func (p *productions) AllByHead() iter.Seq2[NonTerminal, set.Set[Production]] {
+	return p.table.All()
+}
+
+// AnyMatch returns true if at least one production rule satisfies the provided predicate.
+func (p *productions) AnyMatch(pred generic.Predicate1[Production]) bool {
+	for q := range p.All() {
+		if pred(q) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// AllMatch returns true if all production rules satisfy the provided predicate.
+// If the set of production rules is empty, it returns true.
+func (p *productions) AllMatch(pred generic.Predicate1[Production]) bool {
+	for q := range p.All() {
+		if !pred(q) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// SelectMatch selects a subset of production rules that satisfy the given predicate.
+// It returns a new set of production rules containing the matching productions, of the same type as the original set of production rules.
+func (p *productions) SelectMatch(pred generic.Predicate1[Production]) Productions {
+	newP := NewProductions()
+
+	for q := range p.All() {
+		if pred(q) {
+			newP.Add(q)
+		}
+	}
+
+	return newP
+}

--- a/internal/grammar/production_test.go
+++ b/internal/grammar/production_test.go
@@ -1,0 +1,713 @@
+package grammar
+
+import (
+	"testing"
+
+	"github.com/moorara/algo/generic"
+	"github.com/moorara/algo/set"
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestProductions() []*productions {
+	p0 := NewProductions().(*productions)
+
+	p1 := NewProductions().(*productions)
+	p1.Add(Production{"S", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b"), NonTerminal("S")}}) // S → aSbS
+	p1.Add(Production{"S", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a"), NonTerminal("S")}}) // S → bSaS
+	p1.Add(Production{"S", ε})                                                                                // S → ε
+
+	p2 := NewProductions().(*productions)
+	p2.Add(Production{"S", String[Symbol]{NonTerminal("E")}})                                  // S → E
+	p2.Add(Production{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("T")}}) // E → E + T
+	p2.Add(Production{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}}) // E → E - T
+	p2.Add(Production{"E", String[Symbol]{NonTerminal("T")}})                                  // E → T
+	p2.Add(Production{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}) // T → T * F
+	p2.Add(Production{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}) // T → T / F
+	p2.Add(Production{"T", String[Symbol]{NonTerminal("F")}})                                  // T → F
+	p2.Add(Production{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}})    // F → ( E )
+	p2.Add(Production{"F", String[Symbol]{Terminal("id")}})                                    // F → id
+
+	p3 := NewProductions().(*productions)
+	p3.Add(Production{"S", String[Symbol]{NonTerminal("E")}})                                  // S → E
+	p3.Add(Production{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}}) // E → E + E
+	p3.Add(Production{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}}) // E → E - E
+	p3.Add(Production{"E", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}}) // E → E * E
+	p3.Add(Production{"E", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}}) // E → E / E
+	p3.Add(Production{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}})    // E → ( E )
+	p3.Add(Production{"E", String[Symbol]{Terminal("-"), NonTerminal("E")}})                   // E → - E
+	p3.Add(Production{"E", String[Symbol]{Terminal("id")}})                                    // E → id
+
+	return []*productions{p0, p1, p2, p3}
+}
+
+func TestProduction(t *testing.T) {
+	tests := []struct {
+		name                    string
+		p                       Production
+		expectedString          string
+		expectedIsEmpty         bool
+		expectedIsSingle        bool
+		expectedIsLeftRecursive bool
+	}{
+		{
+			name:                    "1st",
+			p:                       Production{"S", ε},
+			expectedString:          `S → ε`,
+			expectedIsEmpty:         true,
+			expectedIsSingle:        false,
+			expectedIsLeftRecursive: false,
+		},
+		{
+			name:                    "2nd",
+			p:                       Production{"A", String[Symbol]{NonTerminal("A")}},
+			expectedString:          `A → A`,
+			expectedIsEmpty:         false,
+			expectedIsSingle:        true,
+			expectedIsLeftRecursive: true,
+		},
+		{
+			name:                    "3rd",
+			p:                       Production{"A", String[Symbol]{NonTerminal("B")}},
+			expectedString:          `A → B`,
+			expectedIsEmpty:         false,
+			expectedIsSingle:        true,
+			expectedIsLeftRecursive: false,
+		},
+		{
+			name:                    "4th",
+			p:                       Production{"A", String[Symbol]{NonTerminal("A"), Terminal("a")}},
+			expectedString:          `A → A "a"`,
+			expectedIsEmpty:         false,
+			expectedIsSingle:        false,
+			expectedIsLeftRecursive: true,
+		},
+		{
+			name:                    "5th",
+			p:                       Production{"A", String[Symbol]{NonTerminal("A"), NonTerminal("B")}},
+			expectedString:          `A → A B`,
+			expectedIsEmpty:         false,
+			expectedIsSingle:        false,
+			expectedIsLeftRecursive: true,
+		},
+		{
+			name:                    "6th",
+			p:                       Production{"stmt", String[Symbol]{Terminal("if"), NonTerminal("expr"), Terminal("then"), NonTerminal("stmt")}},
+			expectedString:          `stmt → "if" expr "then" stmt`,
+			expectedIsEmpty:         false,
+			expectedIsSingle:        false,
+			expectedIsLeftRecursive: false,
+		},
+	}
+
+	notEqual := Production{"😐", String[Symbol]{Terminal("🙂"), NonTerminal("🙃")}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedString, tc.p.String())
+			assert.True(t, tc.p.Equals(tc.p))
+			assert.False(t, tc.p.Equals(notEqual))
+			assert.Equal(t, tc.expectedIsEmpty, tc.p.IsEmpty())
+			assert.Equal(t, tc.expectedIsSingle, tc.p.IsSingle())
+			assert.Equal(t, tc.expectedIsLeftRecursive, tc.p.IsLeftRecursive())
+		})
+	}
+}
+
+func TestNewProductions(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		p := NewProductions()
+		assert.NotNil(t, p)
+	})
+}
+
+func TestProductions_String(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name               string
+		p                  *productions
+		expectedSubstrings []string
+	}{
+		{
+			name: "1st",
+			p:    p[1],
+			expectedSubstrings: []string{
+				`S → "a" S "b" S | "b" S "a" S | ε`,
+			},
+		},
+		{
+			name: "2nd",
+			p:    p[2],
+			expectedSubstrings: []string{
+				`S → E`,
+				`E → E "+" T | E "-" T | T`,
+				`T → T "*" F | T "/" F | F`,
+				`F → "(" E ")" | "id"`,
+			},
+		},
+		{
+			name: "3rd",
+			p:    p[3],
+			expectedSubstrings: []string{
+				`S → E`,
+				`E → E "*" E | E "+" E | E "-" E | E "/" E | "(" E ")" | "-" E | "id"`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := tc.p.String()
+
+			for _, expectedSubstring := range tc.expectedSubstrings {
+				assert.Contains(t, s, expectedSubstring)
+			}
+		})
+	}
+}
+
+func TestProductions_Equals(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name           string
+		p              *productions
+		rhs            Productions
+		expectedEquals bool
+	}{
+		{
+			name:           "Equal",
+			p:              p[2],
+			rhs:            p[2],
+			expectedEquals: true,
+		},
+		{
+			name:           "NotEqual",
+			p:              p[2],
+			rhs:            p[3],
+			expectedEquals: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedEquals, tc.p.Equals(tc.rhs))
+		})
+	}
+}
+
+func TestProductions_Clone(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name string
+		p    *productions
+	}{
+		{
+			name: "1st",
+			p:    p[1],
+		},
+		{
+			name: "2nd",
+			p:    p[2],
+		},
+		{
+			name: "3rd",
+			p:    p[3],
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q := tc.p.Clone()
+			assert.False(t, q == tc.p)
+			assert.True(t, q.Equals(tc.p))
+		})
+	}
+}
+
+func TestProductions_Add(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name                string
+		p                   *productions
+		ps                  []Production
+		expectedProductions *productions
+	}{
+		{
+			name: "1st",
+			p:    p[1],
+			ps: []Production{
+				{"S", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b"), NonTerminal("S")}}, // S → aSbS
+				{"S", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a"), NonTerminal("S")}}, // S → bSaS
+				{"S", ε}, // S → ε
+			},
+			expectedProductions: p[1],
+		},
+		{
+			name: "2nd",
+			p:    p[2],
+			ps: []Production{
+				{"S", String[Symbol]{NonTerminal("E")}},                                  // S → E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("T")}}, // E → E + T
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}}, // E → E - T
+				{"E", String[Symbol]{NonTerminal("T")}},                                  // E → T
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
+				{"T", String[Symbol]{NonTerminal("F")}},                                  // T → F
+				{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // F → ( E )
+				{"F", String[Symbol]{Terminal("id")}},                                    // F → id
+			},
+			expectedProductions: p[2],
+		},
+		{
+			name: "3rd",
+			p:    p[3],
+			ps: []Production{
+				{"S", String[Symbol]{NonTerminal("E")}},                                  // S → E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}}, // E → E + E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}}, // E → E - E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}}, // E → E * E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}}, // E → E / E
+				{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // E → ( E )
+				{"E", String[Symbol]{Terminal("-"), NonTerminal("E")}},                   // E → - E
+				{"E", String[Symbol]{Terminal("id")}},                                    // E → id
+			},
+			expectedProductions: p[3],
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.p.Add(tc.ps...)
+			assert.True(t, tc.p.Equals(tc.expectedProductions))
+		})
+	}
+}
+
+func TestProductions_Remove(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name                string
+		p                   *productions
+		ps                  []Production
+		expectedProductions *productions
+	}{
+		{
+			name: "1st",
+			p:    p[1],
+			ps: []Production{
+				{"S", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b"), NonTerminal("S")}}, // S → aSbS
+				{"S", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a"), NonTerminal("S")}}, // S → bSaS
+				{"S", ε}, // S → ε
+			},
+			expectedProductions: p[0],
+		},
+		{
+			name: "2nd",
+			p:    p[2],
+			ps: []Production{
+				{"S", String[Symbol]{NonTerminal("E")}},                                  // S → E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("T")}}, // E → E + T
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}}, // E → E - T
+				{"E", String[Symbol]{NonTerminal("T")}},                                  // E → T
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
+				{"T", String[Symbol]{NonTerminal("F")}},                                  // T → F
+				{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // F → ( E )
+				{"F", String[Symbol]{Terminal("id")}},                                    // F → id
+			},
+			expectedProductions: p[0],
+		},
+		{
+			name: "3rd",
+			p:    p[3],
+			ps: []Production{
+				{"S", String[Symbol]{NonTerminal("E")}},                                  // S → E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}}, // E → E + E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}}, // E → E - E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}}, // E → E * E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}}, // E → E / E
+				{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // E → ( E )
+				{"E", String[Symbol]{Terminal("-"), NonTerminal("E")}},                   // E → - E
+				{"E", String[Symbol]{Terminal("id")}},                                    // E → id
+			},
+			expectedProductions: p[0],
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.p.Remove(tc.ps...)
+			assert.True(t, tc.p.Equals(tc.expectedProductions))
+		})
+	}
+}
+
+func TestProductions_RemoveAll(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name                string
+		p                   *productions
+		heads               []NonTerminal
+		expectedProductions *productions
+	}{
+		{
+			name:                "1st",
+			p:                   p[1],
+			heads:               []NonTerminal{"S"},
+			expectedProductions: p[0],
+		},
+		{
+			name:                "2nd",
+			p:                   p[2],
+			heads:               []NonTerminal{"S", "E", "T", "F"},
+			expectedProductions: p[0],
+		},
+		{
+			name:                "3rd",
+			p:                   p[3],
+			heads:               []NonTerminal{"S", "E"},
+			expectedProductions: p[0],
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.p.RemoveAll(tc.heads...)
+			assert.True(t, tc.p.Equals(tc.expectedProductions))
+		})
+	}
+}
+
+func TestProductions_Get(t *testing.T) {
+	p := getTestProductions()
+
+	s1 := set.New[Production](eqProduction)
+	s1.Add(Production{"S", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b"), NonTerminal("S")}}) // S → aSbS
+	s1.Add(Production{"S", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a"), NonTerminal("S")}}) // S → bSaS
+	s1.Add(Production{"S", ε})                                                                                // S → ε
+
+	s2 := set.New[Production](eqProduction)
+	s2.Add(Production{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}) // T → T * F
+	s2.Add(Production{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}) // T → T / F
+	s2.Add(Production{"T", String[Symbol]{NonTerminal("F")}})                                  // T → F
+
+	s3 := set.New[Production](eqProduction)
+	s3.Add(Production{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}}) // E → E + E
+	s3.Add(Production{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}}) // E → E - E
+	s3.Add(Production{"E", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}}) // E → E * E
+	s3.Add(Production{"E", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}}) // E → E / E
+	s3.Add(Production{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}})    // E → ( E )
+	s3.Add(Production{"E", String[Symbol]{Terminal("-"), NonTerminal("E")}})                   // E → - E
+	s3.Add(Production{"E", String[Symbol]{Terminal("id")}})                                    // E → id
+
+	tests := []struct {
+		name                string
+		p                   *productions
+		head                NonTerminal
+		expectedProductions set.Set[Production]
+	}{
+		{
+			name:                "Nil",
+			p:                   p[0],
+			head:                NonTerminal("E"),
+			expectedProductions: nil,
+		},
+		{
+			name:                "1st",
+			p:                   p[1],
+			head:                NonTerminal("S"),
+			expectedProductions: s1,
+		},
+		{
+			name:                "2nd",
+			p:                   p[2],
+			head:                NonTerminal("T"),
+			expectedProductions: s2,
+		},
+		{
+			name:                "3rd",
+			p:                   p[3],
+			head:                NonTerminal("E"),
+			expectedProductions: s3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prods := tc.p.Get(tc.head)
+
+			if tc.expectedProductions == nil {
+				assert.Nil(t, prods)
+			} else {
+				assert.True(t, prods.Equals(tc.expectedProductions))
+			}
+		})
+	}
+}
+
+func TestProductions_Order(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name                string
+		p                   *productions
+		head                NonTerminal
+		expectedProductions []Production
+	}{
+		{
+			name: "1st",
+			p:    p[1],
+			head: NonTerminal("S"),
+			expectedProductions: []Production{
+				{"S", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b"), NonTerminal("S")}}, // S → aSbS
+				{"S", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a"), NonTerminal("S")}}, // S → bSaS
+				{"S", ε}, // S → ε
+			},
+		},
+		{
+			name: "2nd",
+			p:    p[2],
+			head: NonTerminal("T"),
+			expectedProductions: []Production{
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
+				{"T", String[Symbol]{NonTerminal("F")}},                                  // T → F
+			},
+		},
+		{
+			name: "3rd",
+			p:    p[3],
+			head: NonTerminal("E"),
+			expectedProductions: []Production{
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}}, // E → E * E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}}, // E → E + E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}}, // E → E - E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}}, // E → E / E
+				{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // E → ( E )
+				{"E", String[Symbol]{Terminal("-"), NonTerminal("E")}},                   // E → - E
+				{"E", String[Symbol]{Terminal("id")}},                                    // E → id
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prods := tc.p.Order(tc.head)
+			assert.Equal(t, tc.expectedProductions, prods)
+		})
+	}
+}
+
+func TestProductions_All(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name                string
+		p                   *productions
+		expectedProductions []Production
+	}{
+		{
+			name: "1st",
+			p:    p[1],
+			expectedProductions: []Production{
+				{"S", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b"), NonTerminal("S")}}, // S → aSbS
+				{"S", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a"), NonTerminal("S")}}, // S → bSaS
+				{"S", ε}, // S → ε
+			},
+		},
+		{
+			name: "2nd",
+			p:    p[2],
+			expectedProductions: []Production{
+				{"S", String[Symbol]{NonTerminal("E")}},                                  // S → E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("T")}}, // E → E + T
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}}, // E → E - T
+				{"E", String[Symbol]{NonTerminal("T")}},                                  // E → T
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
+				{"T", String[Symbol]{NonTerminal("F")}},                                  // T → F
+				{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // F → ( E )
+				{"F", String[Symbol]{Terminal("id")}},                                    // F → id
+			},
+		},
+		{
+			name: "3rd",
+			p:    p[3],
+			expectedProductions: []Production{
+				{"S", String[Symbol]{NonTerminal("E")}},                                  // S → E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}}, // E → E + E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}}, // E → E - E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}}, // E → E * E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}}, // E → E / E
+				{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // E → ( E )
+				{"E", String[Symbol]{Terminal("-"), NonTerminal("E")}},                   // E → - E
+				{"E", String[Symbol]{Terminal("id")}},                                    // E → id
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for p := range tc.p.All() {
+				assert.Contains(t, tc.expectedProductions, p)
+			}
+		})
+	}
+}
+
+func TestProductions_AllByHead(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name                string
+		p                   *productions
+		expectedProductions []Production
+	}{
+		{
+			name: "1st",
+			p:    p[1],
+			expectedProductions: []Production{
+				{"S", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b"), NonTerminal("S")}}, // S → aSbS
+				{"S", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a"), NonTerminal("S")}}, // S → bSaS
+				{"S", ε}, // S → ε
+			},
+		},
+		{
+			name: "2nd",
+			p:    p[2],
+			expectedProductions: []Production{
+				{"S", String[Symbol]{NonTerminal("E")}},                                  // S → E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("T")}}, // E → E + T
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("T")}}, // E → E - T
+				{"E", String[Symbol]{NonTerminal("T")}},                                  // E → T
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
+				{"T", String[Symbol]{NonTerminal("F")}},                                  // T → F
+				{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // F → ( E )
+				{"F", String[Symbol]{Terminal("id")}},                                    // F → id
+			},
+		},
+		{
+			name: "3rd",
+			p:    p[3],
+			expectedProductions: []Production{
+				{"S", String[Symbol]{NonTerminal("E")}},                                  // S → E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}}, // E → E + E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}}, // E → E - E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}}, // E → E * E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}}, // E → E / E
+				{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // E → ( E )
+				{"E", String[Symbol]{Terminal("-"), NonTerminal("E")}},                   // E → - E
+				{"E", String[Symbol]{Terminal("id")}},                                    // E → id
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for head, list := range tc.p.AllByHead() {
+				for p := range list.All() {
+					assert.True(t, p.Head.Equals(head))
+					assert.Contains(t, tc.expectedProductions, p)
+				}
+			}
+		})
+	}
+}
+
+func TestProductions_AnyMatch(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name             string
+		p                *productions
+		pred             generic.Predicate1[Production]
+		expectedAnyMatch bool
+	}{
+		{
+			name:             "OK",
+			p:                p[2],
+			pred:             func(p Production) bool { return p.IsSingle() },
+			expectedAnyMatch: true,
+		},
+		{
+			name:             "NotOK",
+			p:                p[2],
+			pred:             func(p Production) bool { return p.IsEmpty() },
+			expectedAnyMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			anyMatch := tc.p.AnyMatch(tc.pred)
+			assert.Equal(t, tc.expectedAnyMatch, anyMatch)
+		})
+	}
+}
+
+func TestProductions_AllMatch(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name             string
+		p                *productions
+		pred             generic.Predicate1[Production]
+		expectedAllMatch bool
+	}{
+		{
+			name:             "OK",
+			p:                p[2],
+			pred:             func(p Production) bool { return !p.IsEmpty() },
+			expectedAllMatch: true,
+		},
+		{
+			name:             "NotOK",
+			p:                p[2],
+			pred:             func(p Production) bool { return !p.IsSingle() },
+			expectedAllMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			allMatch := tc.p.AllMatch(tc.pred)
+			assert.Equal(t, tc.expectedAllMatch, allMatch)
+		})
+	}
+}
+
+func TestProductions_SelectMatch(t *testing.T) {
+	p := getTestProductions()
+
+	q1 := NewProductions().(*productions)
+	q1.Add(Production{"S", String[Symbol]{NonTerminal("E")}}) // S → E
+	q1.Add(Production{"E", String[Symbol]{NonTerminal("T")}}) // E → T
+	q1.Add(Production{"T", String[Symbol]{NonTerminal("F")}}) // T → F
+
+	tests := []struct {
+		name                string
+		p                   *productions
+		pred                generic.Predicate1[Production]
+		expectedSelectMatch *productions
+	}{
+		{
+			name:                "OK",
+			p:                   p[2],
+			pred:                func(p Production) bool { return p.IsSingle() },
+			expectedSelectMatch: q1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			selectMatch := tc.p.SelectMatch(tc.pred)
+			assert.True(t, selectMatch.Equals(tc.expectedSelectMatch))
+		})
+	}
+}

--- a/internal/grammar/string.go
+++ b/internal/grammar/string.go
@@ -1,0 +1,91 @@
+package grammar
+
+import (
+	"strings"
+)
+
+// The empty string ε
+var ε = String[Symbol]{}
+
+// String represent a string of grammar symbols.
+type String[T Symbol] []T
+
+// String returns a string representation of a string of symbols.
+func (s String[T]) String() string {
+	if len(s) == 0 {
+		return "ε"
+	}
+
+	names := make([]string, len(s))
+	for i, symbol := range s {
+		names[i] = symbol.String()
+	}
+
+	return strings.Join(names, " ")
+}
+
+// Equals determines whether or not two strings are the same.
+func (s String[T]) Equals(rhs String[T]) bool {
+	if len(s) != len(rhs) {
+		return false
+	}
+
+	for i := range s {
+		if !s[i].Equals(rhs[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Append appends new symbols to the current string and returns a new string
+func (s String[T]) Append(symbols ...T) String[T] {
+	newS := make(String[T], len(s)+len(symbols))
+
+	copy(newS, s)
+	copy(newS[len(s):], symbols)
+
+	return newS
+}
+
+// Concat concatenates the current string with one or more strings and returns a new string.
+func (s String[T]) Concat(ss ...String[T]) String[T] {
+	l := len(s)
+	for _, t := range ss {
+		l += len(t)
+	}
+
+	newS := make(String[T], l)
+
+	copy(newS, s)
+	i := len(s)
+	for _, t := range ss {
+		copy(newS[i:], t)
+		i += len(t)
+	}
+
+	return newS
+}
+
+// Terminals returns all terminal symbols of a string of symbols.
+func (s String[Symbol]) Terminals() String[Terminal] {
+	terms := String[Terminal]{}
+	for _, sym := range s {
+		if v, ok := any(sym).(Terminal); ok {
+			terms = append(terms, v)
+		}
+	}
+	return terms
+}
+
+// NonTerminals returns all non-terminal symbols of a string of symbols.
+func (s String[Symbol]) NonTerminals() String[NonTerminal] {
+	nonTerms := String[NonTerminal]{}
+	for _, sym := range s {
+		if v, ok := any(sym).(NonTerminal); ok {
+			nonTerms = append(nonTerms, v)
+		}
+	}
+	return nonTerms
+}

--- a/internal/grammar/string_test.go
+++ b/internal/grammar/string_test.go
@@ -1,0 +1,79 @@
+package grammar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		name                 string
+		s                    String[Symbol]
+		expectedString       string
+		append               []Symbol
+		expectedAppend       String[Symbol]
+		concat               []String[Symbol]
+		expectedConcat       String[Symbol]
+		expectedTerminals    String[Terminal]
+		expectedNonTerminals String[NonTerminal]
+	}{
+		{
+			name:                 "Empty",
+			s:                    ε,
+			expectedString:       `ε`,
+			append:               []Symbol{},
+			expectedAppend:       ε,
+			concat:               []String[Symbol]{ε},
+			expectedConcat:       ε,
+			expectedTerminals:    String[Terminal]{},
+			expectedNonTerminals: String[NonTerminal]{},
+		},
+		{
+			name:                 "AllTerminals",
+			s:                    String[Symbol]{Terminal("a"), Terminal("b"), Terminal("c")},
+			expectedString:       `"a" "b" "c"`,
+			append:               []Symbol{Terminal("d")},
+			expectedAppend:       String[Symbol]{Terminal("a"), Terminal("b"), Terminal("c"), Terminal("d")},
+			concat:               []String[Symbol]{{Terminal("d"), Terminal("e"), Terminal("f")}},
+			expectedConcat:       String[Symbol]{Terminal("a"), Terminal("b"), Terminal("c"), Terminal("d"), Terminal("e"), Terminal("f")},
+			expectedTerminals:    String[Terminal]{"a", "b", "c"},
+			expectedNonTerminals: String[NonTerminal]{},
+		},
+		{
+			name:                 "AllNonTerminals",
+			s:                    String[Symbol]{NonTerminal("A"), NonTerminal("B"), NonTerminal("C")},
+			expectedString:       `A B C`,
+			append:               []Symbol{NonTerminal("D")},
+			expectedAppend:       String[Symbol]{NonTerminal("A"), NonTerminal("B"), NonTerminal("C"), NonTerminal("D")},
+			concat:               []String[Symbol]{{NonTerminal("D"), NonTerminal("E"), NonTerminal("F")}},
+			expectedConcat:       String[Symbol]{NonTerminal("A"), NonTerminal("B"), NonTerminal("C"), NonTerminal("D"), NonTerminal("E"), NonTerminal("F")},
+			expectedTerminals:    String[Terminal]{},
+			expectedNonTerminals: String[NonTerminal]{"A", "B", "C"},
+		},
+		{
+			name:                 "TerminalsAndNonTerminals",
+			s:                    String[Symbol]{Terminal("a"), NonTerminal("A"), Terminal("b"), NonTerminal("B"), Terminal("c")},
+			expectedString:       `"a" A "b" B "c"`,
+			append:               []Symbol{NonTerminal("C"), Terminal("d"), NonTerminal("D")},
+			expectedAppend:       String[Symbol]{Terminal("a"), NonTerminal("A"), Terminal("b"), NonTerminal("B"), Terminal("c"), NonTerminal("C"), Terminal("d"), NonTerminal("D")},
+			concat:               []String[Symbol]{{NonTerminal("C")}, {Terminal("d"), NonTerminal("D")}},
+			expectedConcat:       String[Symbol]{Terminal("a"), NonTerminal("A"), Terminal("b"), NonTerminal("B"), Terminal("c"), NonTerminal("C"), Terminal("d"), NonTerminal("D")},
+			expectedTerminals:    String[Terminal]{"a", "b", "c"},
+			expectedNonTerminals: String[NonTerminal]{"A", "B"},
+		},
+	}
+
+	notEqual := String[Symbol]{Terminal("🙂"), NonTerminal("🙃")}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedString, tc.s.String())
+			assert.Equal(t, tc.expectedTerminals, tc.s.Terminals())
+			assert.Equal(t, tc.expectedNonTerminals, tc.s.NonTerminals())
+			assert.True(t, tc.s.Equals(tc.s))
+			assert.False(t, tc.s.Equals(notEqual))
+			assert.Equal(t, tc.expectedConcat, tc.s.Concat(tc.concat...))
+		})
+	}
+}

--- a/internal/grammar/symbol.go
+++ b/internal/grammar/symbol.go
@@ -1,0 +1,82 @@
+package grammar
+
+import (
+	"fmt"
+
+	"github.com/moorara/algo/generic"
+	"github.com/moorara/algo/hash"
+)
+
+var (
+	eqTerminal  = generic.NewEqualFunc[Terminal]()
+	cmpTerminal = generic.NewCompareFunc[Terminal]()
+
+	eqNonTerminal   = generic.NewEqualFunc[NonTerminal]()
+	cmpNonTerminal  = generic.NewCompareFunc[NonTerminal]()
+	hashNonTerminal = hash.HashFuncForString[NonTerminal](nil)
+)
+
+// Symbol represents a grammar symbol (terminal or non-terminal).
+type Symbol interface {
+	fmt.Stringer
+
+	Name() string
+	Equals(Symbol) bool
+	IsTerminal() bool
+}
+
+// Terminal represents a terminal symbol.
+// Terminals are the basic symbols from which strings of a language are formed.
+// Token name or token for short are equivalent to terminal.
+type Terminal string
+
+// String returns a string representation of a terminal symbol.
+func (t Terminal) String() string {
+	return fmt.Sprintf("%q", t.Name())
+}
+
+// Name returns the name of terminal symbol.
+func (t Terminal) Name() string {
+	return string(t)
+}
+
+// Equals determines whether or not two terminal symbols are the same.
+func (t Terminal) Equals(rhs Symbol) bool {
+	if v, ok := rhs.(Terminal); ok {
+		return t == v
+	}
+	return false
+}
+
+// IsTerminal always returns true for terminal symbols.
+func (t Terminal) IsTerminal() bool {
+	return true
+}
+
+// NonTerminal represents a non-terminal symbol.
+// Non-terminals are syntaxtic variables that denote sets of strings.
+// Non-terminals impose a hierarchical structure on a language.
+type NonTerminal string
+
+// String returns a string representation of a non-terminal symbol.
+func (n NonTerminal) String() string {
+	return n.Name()
+}
+
+// Name returns the name of non-terminal symbol.
+func (n NonTerminal) Name() string {
+	return string(n)
+}
+
+// Equals determines whether or not two non-terminal symbols are the same.
+func (n NonTerminal) Equals(rhs Symbol) bool {
+	if v, ok := rhs.(NonTerminal); ok {
+		return n == v
+	}
+	return false
+}
+
+// IsTerminal always returns false for non-terminal symbols.
+func (n NonTerminal) IsTerminal() bool {
+	return false
+}

--- a/internal/grammar/symbol_test.go
+++ b/internal/grammar/symbol_test.go
@@ -1,0 +1,68 @@
+package grammar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerminal(t *testing.T) {
+	tests := []struct {
+		value          string
+		expectedString string
+	}{
+		{value: "a", expectedString: `"a"`},
+		{value: "b", expectedString: `"b"`},
+		{value: "c", expectedString: `"c"`},
+		{value: "0", expectedString: `"0"`},
+		{value: "1", expectedString: `"1"`},
+		{value: "2", expectedString: `"2"`},
+		{value: "+", expectedString: `"+"`},
+		{value: "*", expectedString: `"*"`},
+		{value: "(", expectedString: `"("`},
+		{value: ")", expectedString: `")"`},
+		{value: "id", expectedString: `"id"`},
+		{value: "if", expectedString: `"if"`},
+	}
+
+	notEqual := Terminal("🙂")
+
+	for _, tc := range tests {
+		t.Run(tc.value, func(t *testing.T) {
+			tr := Terminal(tc.value)
+			assert.Equal(t, tc.expectedString, tr.String())
+			assert.Equal(t, tc.value, tr.Name())
+			assert.True(t, tr.Equals(Terminal(tc.value)))
+			assert.False(t, tr.Equals(NonTerminal(tc.value)))
+			assert.False(t, tr.Equals(notEqual))
+			assert.True(t, tr.IsTerminal())
+		})
+	}
+}
+
+func TestNonTerminal(t *testing.T) {
+	tests := []struct {
+		value string
+	}{
+		{value: "A"},
+		{value: "B"},
+		{value: "C"},
+		{value: "S"},
+		{value: "expr"},
+		{value: "stmt"},
+	}
+
+	notEqual := NonTerminal("🙂")
+
+	for _, tc := range tests {
+		t.Run(tc.value, func(t *testing.T) {
+			n := NonTerminal(tc.value)
+			assert.Equal(t, tc.value, n.String())
+			assert.Equal(t, tc.value, n.Name())
+			assert.True(t, n.Equals(NonTerminal(tc.value)))
+			assert.False(t, n.Equals(Terminal(tc.value)))
+			assert.False(t, n.Equals(notEqual))
+			assert.False(t, n.IsTerminal())
+		})
+	}
+}


### PR DESCRIPTION
## Description

  - [x] Implement `EliminateLeftRecursion` for `Grammar`
  - [x] Update documentation
  - [x] Misc refactoring

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
