### PR TITLE
Fix regex parser to accept more escaped characters

### DIFF
--- a/internal/regex/parser/ast/ast_test.go
+++ b/internal/regex/parser/ast/ast_test.go
@@ -115,7 +115,64 @@ func TestParse(t *testing.T) {
 			expectedLastPos:  Poses{6},
 		},
 		{
-			name:  "Success_Complex",
+			name:  "Success_EscapedChars",
+			regex: `\n|\r|\r\n`,
+			expectedAST: &AST{
+				Root: &Concat{
+					Exprs: []Node{
+						&Alt{
+							Exprs: []Node{
+								&Concat{
+									Exprs: []Node{
+										&Char{Lo: '\n', Hi: '\n', Pos: 1},
+									},
+								},
+								&Alt{
+									Exprs: []Node{
+										&Concat{
+											Exprs: []Node{
+												&Char{Lo: '\r', Hi: '\r', Pos: 2},
+											},
+										},
+										&Concat{
+											Exprs: []Node{
+												&Char{Lo: '\r', Hi: '\r', Pos: 3},
+												&Char{Lo: '\n', Hi: '\n', Pos: 4},
+											},
+										},
+									},
+								},
+							},
+						},
+						&Char{Lo: endMarker, Hi: endMarker, Pos: 5},
+					},
+				},
+				lastPos: 5,
+				posToChar: map[Pos]char.Range{
+					1: {'\n', '\n'},
+					2: {'\r', '\r'},
+					3: {'\r', '\r'},
+					4: {'\n', '\n'},
+					5: {endMarker, endMarker},
+				},
+				charToPos: map[char.Range]Poses{
+					{'\n', '\n'}:           {1, 4},
+					{'\r', '\r'}:           {2, 3},
+					{endMarker, endMarker}: {5},
+				},
+				follows: map[Pos]Poses{
+					1: {5},
+					2: {5},
+					3: {4},
+					4: {5},
+				},
+			},
+			expectedNullable: false,
+			expectedFirstPos: Poses{1, 2, 3},
+			expectedLastPos:  Poses{5},
+		},
+		{
+			name:  "Success_CharRanges",
 			regex: `^[a-f][0-9a-f]*$`,
 			expectedAST: &AST{
 				Root: &Concat{

--- a/internal/regex/parser/nfa/nfa_test.go
+++ b/internal/regex/parser/nfa/nfa_test.go
@@ -18,6 +18,18 @@ var testNFA = map[string]*automata.NFA{
 		AddTransition(0, 'x', 'x', []automata.State{1}).
 		Build(),
 
+	"\n": automata.NewNFABuilder().
+		SetStart(0).
+		SetFinal([]automata.State{1}).
+		AddTransition(0, '\n', '\n', []automata.State{1}).
+		Build(),
+
+	"\r": automata.NewNFABuilder().
+		SetStart(0).
+		SetFinal([]automata.State{1}).
+		AddTransition(0, '\r', '\r', []automata.State{1}).
+		Build(),
+
 	/* CHAR CLASSES */
 
 	"ws": automata.NewNFABuilder().
@@ -506,7 +518,16 @@ func TestParse(t *testing.T) {
 			expectedError: "invalid repetition range {4,2}",
 		},
 		{
-			name:  "Success",
+			name:  "Success_EscapedChars",
+			regex: `\n|\r|\r\n`,
+			expectedNFA: testNFA["\n"].Union(
+				testNFA["\r"].Union(
+					testNFA["\r"].Concat(testNFA["\n"]),
+				),
+			),
+		},
+		{
+			name:  "Success_CharRanges",
 			regex: `^[A-Z]?[a-z][0-9A-Za-z]{1,}$`,
 			expectedNFA: empty().Union(testNFA["upper"]).Concat(
 				testNFA["lower"],

--- a/internal/regex/parser/parser_test.go
+++ b/internal/regex/parser/parser_test.go
@@ -168,28 +168,6 @@ func TestToEscapedChar(t *testing.T) {
 			expectedOK:     true,
 		},
 		{
-			name: "VerticalTab",
-			r: comb.Result{
-				Val: comb.List{
-					{Val: '\\', Pos: 1},
-					{Val: 'v', Pos: 2},
-				},
-			},
-			expectedResult: comb.Result{Val: '\v', Pos: 1},
-			expectedOK:     true,
-		},
-		{
-			name: "FormFeed",
-			r: comb.Result{
-				Val: comb.List{
-					{Val: '\\', Pos: 1},
-					{Val: 'f', Pos: 2},
-				},
-			},
-			expectedResult: comb.Result{Val: '\f', Pos: 1},
-			expectedOK:     true,
-		},
-		{
 			name: "CarriageReturn",
 			r: comb.Result{
 				Val: comb.List{
@@ -198,6 +176,160 @@ func TestToEscapedChar(t *testing.T) {
 				},
 			},
 			expectedResult: comb.Result{Val: '\r', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "Bar",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '|', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '|', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "Dot",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '.', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '.', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "Question",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '?', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '?', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "Asterisk",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '*', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '*', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "Plus",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '+', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '+', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "Hyphen",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '-', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '-', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "OpenningParenthesis",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '(', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '(', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "ClosingParenthesis",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: ')', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: ')', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "OpenningBracket",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '[', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '[', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "ClosingBracket",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: ']', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: ']', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "OpenningBrace",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '{', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '{', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "ClosingBrace",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '}', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '}', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "Caret",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '^', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '^', Pos: 1},
+			expectedOK:     true,
+		},
+		{
+			name: "Dollar",
+			r: comb.Result{
+				Val: comb.List{
+					{Val: '\\', Pos: 1},
+					{Val: '$', Pos: 2},
+				},
+			},
+			expectedResult: comb.Result{Val: '$', Pos: 1},
 			expectedOK:     true,
 		},
 	}
@@ -4476,7 +4608,7 @@ func TestParser_Parse(t *testing.T) {
 	}
 }
 
-//==================================================< HELPERS >==================================================
+//==================================================< MAPPERS >==================================================
 
 type MapFuncMock struct {
 	InResult  comb.Result


### PR DESCRIPTION
## Description

  - [x] Regex parser now properly accepts `\t`, `\n`, and `\n`

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
