### PR TITLE
Ignore whitespaces automatically

### DIFF
--- a/docs/1-documentation.md
+++ b/docs/1-documentation.md
@@ -48,9 +48,10 @@ the lexer automaton may recognize more than one token in a final state.
 Tokens defined by string values take precedence over those defined by regular expressions.
 If multiple tokens share the same string value, lexer generation fails.
 
-**Whitespaces** (*space*, *tab*, *newline*, *carriage return*) is automatically discarded unless matched by a token.
-If any token explicitly matches a whitespace, the lexer does not handle it automatically.
-Unmatched whitespaces is always discarded.
+**Whitespaces** (space, tab, newline, carriage return, and all Unicode spacing and breaking characters)
+are skipped by the lexer by default — you do not need to handle them in your grammar.
+If you define a token that matches whitespace, only the characters matched by that token are emitted;
+any remaining whitespace is still ignored.
 
 ### Non-Terminals
 

--- a/internal/ebnf/parser/spec/spec_test.go
+++ b/internal/ebnf/parser/spec/spec_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSpec_DFA(t *testing.T) {
+func TestSpec_BuildLexerDFA(t *testing.T) {
 	tests := []struct {
 		name                   string
 		s                      *Spec
@@ -63,51 +63,79 @@ func TestSpec_DFA(t *testing.T) {
 			},
 			expectedDFA: automata.NewDFABuilder().
 				SetStart(0).
-				SetFinal([]automata.State{1, 2, 3, 4, 5}).
-				AddTransition(0, '0', '9', 1).
-				AddTransition(1, '0', '9', 1).
-				AddTransition(0, ';', ';', 2).
-				AddTransition(0, 'A', 'Z', 3).
-				AddTransition(0, '_', '_', 3).
-				AddTransition(0, 'a', 'h', 3).
-				AddTransition(0, 'j', 'z', 3).
-				AddTransition(0, 'i', 'i', 4).
-				AddTransition(3, '0', '9', 3).
-				AddTransition(3, 'A', 'Z', 3).
-				AddTransition(3, '_', '_', 3).
-				AddTransition(3, 'a', 'z', 3).
-				AddTransition(4, '0', '9', 3).
-				AddTransition(4, 'A', 'Z', 3).
-				AddTransition(4, '_', '_', 3).
-				AddTransition(4, 'a', 'e', 3).
-				AddTransition(4, 'g', 'z', 3).
-				AddTransition(4, 'f', 'f', 5).
-				AddTransition(5, '0', '9', 3).
-				AddTransition(5, 'A', 'Z', 3).
-				AddTransition(5, '_', '_', 3).
-				AddTransition(5, 'a', 'z', 3).
+				SetFinal([]automata.State{1, 2, 3, 4, 5, 6}).
+				AddTransition(0, '\t', '\n', 1).
+				AddTransition(0, '\r', '\r', 1).
+				AddTransition(0, ' ', ' ', 1).
+				AddTransition(0, 0x0085, 0x0085, 1).
+				AddTransition(0, 0x00A0, 0x00A0, 1).
+				AddTransition(0, 0x1680, 0x1680, 1).
+				AddTransition(0, 0x2000, 0x200A, 1).
+				AddTransition(0, 0x2028, 0x2029, 1).
+				AddTransition(0, 0x202F, 0x202F, 1).
+				AddTransition(0, 0x205F, 0x205F, 1).
+				AddTransition(0, 0x3000, 0x3000, 1).
+				AddTransition(1, '\t', '\n', 1).
+				AddTransition(1, '\r', '\r', 1).
+				AddTransition(1, ' ', ' ', 1).
+				AddTransition(1, 0x0085, 0x0085, 1).
+				AddTransition(1, 0x00A0, 0x00A0, 1).
+				AddTransition(1, 0x1680, 0x1680, 1).
+				AddTransition(1, 0x2000, 0x200A, 1).
+				AddTransition(1, 0x2028, 0x2029, 1).
+				AddTransition(1, 0x202F, 0x202F, 1).
+				AddTransition(1, 0x205F, 0x205F, 1).
+				AddTransition(1, 0x3000, 0x3000, 1).
+				AddTransition(0, '0', '9', 2).
+				AddTransition(2, '0', '9', 2).
+				AddTransition(0, ';', ';', 3).
+				AddTransition(0, 'A', 'Z', 4).
+				AddTransition(0, '_', '_', 4).
+				AddTransition(0, 'a', 'h', 4).
+				AddTransition(0, 'j', 'z', 4).
+				AddTransition(0, 'i', 'i', 5).
+				AddTransition(4, '0', '9', 4).
+				AddTransition(4, 'A', 'Z', 4).
+				AddTransition(4, '_', '_', 4).
+				AddTransition(4, 'a', 'z', 4).
+				AddTransition(5, '0', '9', 4).
+				AddTransition(5, 'A', 'Z', 4).
+				AddTransition(5, '_', '_', 4).
+				AddTransition(5, 'a', 'e', 4).
+				AddTransition(5, 'g', 'z', 4).
+				AddTransition(5, 'f', 'f', 6).
+				AddTransition(6, '0', '9', 4).
+				AddTransition(6, 'A', 'Z', 4).
+				AddTransition(6, '_', '_', 4).
+				AddTransition(6, 'a', 'z', 4).
 				Build(),
 			expectedTerminalFinals: []FinalTerminalAssociation{
 				{
 					Final:    automata.NewStates(1),
+					Terminal: "WS",
+					Kind:     StringDef,
+					Value:    "",
+				},
+				{
+					Final:    automata.NewStates(2),
 					Terminal: "NUM",
 					Kind:     RegexDef,
 					Value:    "[0-9]+",
 				},
 				{
-					Final:    automata.NewStates(2),
+					Final:    automata.NewStates(3),
 					Terminal: ";",
 					Kind:     StringDef,
 					Value:    ";",
 				},
 				{
-					Final:    automata.NewStates(3, 4),
+					Final:    automata.NewStates(4, 5),
 					Terminal: "ID",
 					Kind:     RegexDef,
 					Value:    "[A-Za-z_][0-9A-Za-z_]*",
 				},
 				{
-					Final:    automata.NewStates(5),
+					Final:    automata.NewStates(6),
 					Terminal: "if",
 					Kind:     StringDef,
 					Value:    "if",
@@ -119,7 +147,7 @@ func TestSpec_DFA(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dfa, termMap, err := tc.s.DFA()
+			dfa, termMap, err := tc.s.BuildLexerDFA()
 
 			if len(tc.expectedErrorStrings) == 0 {
 				assert.NoError(t, err)

--- a/internal/ebnf/parser/spec/symbol_table_test.go
+++ b/internal/ebnf/parser/spec/symbol_table_test.go
@@ -38,41 +38,49 @@ func TestSymbolTable_Reset(t *testing.T) {
 
 func TestSymbolTable_Verify(t *testing.T) {
 	st0 := NewSymbolTable()
-	st0.AddTokenTerminal("QUOT", &lexer.Position{Filename: "test", Offset: 30, Line: 4, Column: 10})
+	st0.AddStringTokenDef("ERR", "error", &lexer.Position{Filename: "test", Offset: 10, Line: 2, Column: 1})
+	st0.AddRegexTokenDef("WS", "\\t", &lexer.Position{Filename: "test", Offset: 20, Line: 3, Column: 1})
 	st0.AddProduction(
 		&grammar.Production{Head: "start", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("QUOT")}},
 		&lexer.Position{Filename: "test", Offset: 60, Line: 6, Column: 1},
 	)
 
 	st1 := NewSymbolTable()
-	st1.AddStringTokenDef("QUOT", "'", &lexer.Position{Filename: "test", Offset: 10, Line: 2, Column: 1})
-	st1.AddStringTokenDef("QUOT", "\"", &lexer.Position{Filename: "test", Offset: 20, Line: 3, Column: 1})
+	st1.AddTokenTerminal("QUOT", &lexer.Position{Filename: "test", Offset: 30, Line: 4, Column: 10})
 	st1.AddProduction(
 		&grammar.Production{Head: "start", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("QUOT")}},
 		&lexer.Position{Filename: "test", Offset: 60, Line: 6, Column: 1},
 	)
 
 	st2 := NewSymbolTable()
-	st2.AddStringTokenDef("INT", "[0-9]+", &lexer.Position{Filename: "test", Offset: 10, Line: 2, Column: 1})
-	st2.AddRegexTokenDef("NUM", "[0-9]+", &lexer.Position{Filename: "test", Offset: 20, Line: 3, Column: 1})
-	st2.AddTokenTerminal("NUM", &lexer.Position{Filename: "test", Offset: 40, Line: 5, Column: 12})
+	st2.AddStringTokenDef("QUOT", "'", &lexer.Position{Filename: "test", Offset: 10, Line: 2, Column: 1})
+	st2.AddStringTokenDef("QUOT", "\"", &lexer.Position{Filename: "test", Offset: 20, Line: 3, Column: 1})
 	st2.AddProduction(
 		&grammar.Production{Head: "start", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("QUOT")}},
 		&lexer.Position{Filename: "test", Offset: 60, Line: 6, Column: 1},
 	)
 
 	st3 := NewSymbolTable()
-	st3.AddStringTokenDef("QUOT", "\"", &lexer.Position{Filename: "test", Offset: 10, Line: 2, Column: 1})
+	st3.AddStringTokenDef("INT", "[0-9]+", &lexer.Position{Filename: "test", Offset: 10, Line: 2, Column: 1})
 	st3.AddRegexTokenDef("NUM", "[0-9]+", &lexer.Position{Filename: "test", Offset: 20, Line: 3, Column: 1})
-	st3.AddTokenTerminal("QUOT", &lexer.Position{Filename: "test", Offset: 30, Line: 4, Column: 10})
 	st3.AddTokenTerminal("NUM", &lexer.Position{Filename: "test", Offset: 40, Line: 5, Column: 12})
+	st3.AddProduction(
+		&grammar.Production{Head: "start", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("QUOT")}},
+		&lexer.Position{Filename: "test", Offset: 60, Line: 6, Column: 1},
+	)
 
 	st4 := NewSymbolTable()
 	st4.AddStringTokenDef("QUOT", "\"", &lexer.Position{Filename: "test", Offset: 10, Line: 2, Column: 1})
 	st4.AddRegexTokenDef("NUM", "[0-9]+", &lexer.Position{Filename: "test", Offset: 20, Line: 3, Column: 1})
 	st4.AddTokenTerminal("QUOT", &lexer.Position{Filename: "test", Offset: 30, Line: 4, Column: 10})
 	st4.AddTokenTerminal("NUM", &lexer.Position{Filename: "test", Offset: 40, Line: 5, Column: 12})
-	st4.AddProduction(
+
+	st5 := NewSymbolTable()
+	st5.AddStringTokenDef("QUOT", "\"", &lexer.Position{Filename: "test", Offset: 10, Line: 2, Column: 1})
+	st5.AddRegexTokenDef("NUM", "[0-9]+", &lexer.Position{Filename: "test", Offset: 20, Line: 3, Column: 1})
+	st5.AddTokenTerminal("QUOT", &lexer.Position{Filename: "test", Offset: 30, Line: 4, Column: 10})
+	st5.AddTokenTerminal("NUM", &lexer.Position{Filename: "test", Offset: 40, Line: 5, Column: 12})
+	st5.AddProduction(
 		&grammar.Production{Head: "start", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("QUOT")}},
 		&lexer.Position{Filename: "test", Offset: 60, Line: 6, Column: 1},
 	)
@@ -83,8 +91,17 @@ func TestSymbolTable_Verify(t *testing.T) {
 		expectedErrorStrings []string
 	}{
 		{
-			name: "NoDefinition",
+			name: "TerminalReserved",
 			st:   st0,
+			expectedErrorStrings: []string{
+				`2 errors occurred:`,
+				`terminal name "ERR" is reserved`,
+				`terminal name "WS" is reserved`,
+			},
+		},
+		{
+			name: "NoDefinition",
+			st:   st1,
 			expectedErrorStrings: []string{
 				`1 error occurred:`,
 				`no definition for terminal "QUOT"`,
@@ -92,7 +109,7 @@ func TestSymbolTable_Verify(t *testing.T) {
 		},
 		{
 			name: "MultipleDefinitions",
-			st:   st1,
+			st:   st2,
 			expectedErrorStrings: []string{
 				`1 error occurred:`,
 				`multiple definitions for terminal "QUOT":`,
@@ -102,7 +119,7 @@ func TestSymbolTable_Verify(t *testing.T) {
 		},
 		{
 			name: "DuplicateDefinitions",
-			st:   st2,
+			st:   st3,
 			expectedErrorStrings: []string{
 				`1 error occurred:`,
 				`multiple definitions with the same value: "[0-9]+"`,
@@ -112,7 +129,7 @@ func TestSymbolTable_Verify(t *testing.T) {
 		},
 		{
 			name: "NoStartSymbol",
-			st:   st3,
+			st:   st4,
 			expectedErrorStrings: []string{
 				`1 error occurred:`,
 				`missing production rule with the start symbol: start`,
@@ -120,7 +137,7 @@ func TestSymbolTable_Verify(t *testing.T) {
 		},
 		{
 			name:                 "OK",
-			st:                   st4,
+			st:                   st5,
 			expectedErrorStrings: nil,
 		},
 	}

--- a/internal/generate/golang/golang.go
+++ b/internal/generate/golang/golang.go
@@ -168,8 +168,8 @@ type coreData struct {
 func (g *generator) generateLexer() error {
 	g.Infof(hotPink, "     Generating the lexer ...")
 
-	g.Infof(hotPink, "       Constructing Automaton ...")
-	dfa, assocs, err := g.Spec.DFA()
+	g.Infof(hotPink, "       Constructing finite automaton ...")
+	dfa, assocs, err := g.Spec.BuildLexerDFA()
 	if err != nil {
 		return err
 	}

--- a/internal/generate/golang/templates/lexer.go.tmpl
+++ b/internal/generate/golang/templates/lexer.go.tmpl
@@ -4,10 +4,8 @@ const (
 )
 
 const (
-	ERR     = Terminal("ERR")     // ERR is the error token.
-	WS      = Terminal("WS")      // WS is the token for whitespace characters.
-	EOL     = Terminal("EOL")     // EOL is the token for newline characters.
-	COMMENT = Terminal("COMMENT") // COMMENT is the token for single-line and multi-line comments.
+	ERR = Terminal("ERR") // ERR is the error token.
+	WS  = Terminal("WS")  // WS is the token for Unicode whitespace characters.
 )
 
 // Lexer is the lexical analyzer, a.k.a. scanner.
@@ -50,8 +48,8 @@ func (l *Lexer) NextToken() (Token, error) {
 			switch token.Terminal {
 			case ERR:
 				return Token{}, errors.New(token.Lexeme)
-			case WS, EOL, COMMENT:
-				// Skip whitespaces, newlines, and comments.
+			case WS:
+				// Skip whitespaces
 				return l.NextToken()
 			default:
 				return token, nil


### PR DESCRIPTION
## Description

  - [x] Handle and ignore all Unicode whitespaces automatically by the lexer

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
