### PR TITLE
regex: remove start of string and end of string anchors

### DIFF
--- a/docs/5-definitions.md
+++ b/docs/5-definitions.md
@@ -22,11 +22,10 @@ we can define the regular expression language using the EBNF notation as well
 
 {% raw %}
 ```
-regex              = ["^"] expr
+regex              = expr
 expr               = subexpr ["|" expr]
 subexpr            = {{subexpr_item}}
-subexpr_item       = anchor | group | match
-anchor             = "$"
+subexpr_item       = group | match
 group              = "(" expr ")" [quantifier]
 match              = match_item [quantifier]
 match_item         = any_char | single_char | char_class | ascii_char_class | unicode_char_class | char_group
@@ -57,8 +56,8 @@ unicode_category   = "Math" | "Emoji"
 
 ascii_char         = "\x" hex_digit{2}
 unicode_char       = "\x" hex_digit{4,8}
-escaped_char       = "\" ("/", "\", "t", "n", "r", "^", "$", "|", ".", "?", "*", "+", "(", ")", "[", "]", "{", "}")
-raw_char           = # all characters except "/", "\\", "\t", "\n", "\r", "^", "$", "|", ".", "?", "*", "+", "(", ")", "[", "]", "{", "}"
+escaped_char       = "\" ("/", "\", "t", "n", "r", "|", ".", "?", "*", "+", "(", ")", "[", "]", "{", "}")
+raw_char           = # all characters except "/", "\\", "\t", "\n", "\r", "|", ".", "?", "*", "+", "(", ")", "[", "]", "{", "}"
 raw_char_in_group  = # all characters except "/", "\\", "\t", "\n", "\r", "[", "]"
 char               = # all characters
 

--- a/docs/6-design.md
+++ b/docs/6-design.md
@@ -7,22 +7,30 @@ In this document, we go over some of the design decisions and rationals behind *
 ### Language Design
 
 The following features are NOT included in Emerge's Regular Expression language.
-They seem unnecessary for the purpose of designing and defining tokens of a language.
+They seem irrelevant for the purpose of designing and defining tokens of a language.
 
   - Backreference
   - Non-capturing group modifier `?:`
   - Lookarounds `?=` `?!` `?<=` `?<!`
   - Anchors:
+      - Start of string `^`
+      - End of string `$`
       - Word boundary `\b`
       - Non-word boundary`\B`
-      - Start of string only `\A`
-      - End of string only `\Z`
-      - End of string only (not newline) `\z`
+      - Start of string `\A`
+      - End of string `\Z`
+      - End of string (not newline) `\z`
       - Previous match end `\G`
+
+In a lexical analyzer, regular expressions are intended to match substrings at any position in the input stream.
+Constraints such as the *start of string*, *end of string*, *word boundary*, etc. should be expressed in the grammar.
 
 The following features are implemented slightly different in Emerge's Regular Expression language.
 
   - The `.` (dot) matches any Unicode character in the range `0x00–0x10FFFF`, including the newlines.
+
+The **lazy quantifiers** (`??`, `*?`, `+?`, `{..}?`) are currently accepted,
+but lazy matching is not implemented at the moment.
 
 ### Parser Design
 

--- a/internal/regex/parser/ast/ast.go
+++ b/internal/regex/parser/ast/ast.go
@@ -947,21 +947,6 @@ func (m *mappers) ToGroup(r combinator.Result) (combinator.Result, error) {
 	}, nil
 }
 
-func (m *mappers) ToAnchor(r combinator.Result) (combinator.Result, error) {
-	c := r.Val.(rune)
-
-	var anchor Anchor
-	switch c {
-	case '$': // end-of-string
-		anchor = EndOfString
-	}
-
-	return combinator.Result{
-		Val: anchor,
-		Pos: r.Pos,
-	}, nil
-}
-
 func (m *mappers) ToSubexprItem(r combinator.Result) (combinator.Result, error) {
 	// Passing the result up the parsing chain
 	return r, nil
@@ -1005,27 +990,8 @@ func (m *mappers) ToExpr(r combinator.Result) (combinator.Result, error) {
 }
 
 func (m *mappers) ToRegex(r combinator.Result) (combinator.Result, error) {
-	r0, _ := r.Get(0)
-	r1, _ := r.Get(1)
-
-	pos := r1.Pos
-	var bag combinator.Bag
-
-	// Check whether or not the start-of-string is present
-	if _, sos := r0.Val.(rune); sos {
-		pos = r0.Pos
-		bag = combinator.Bag{
-			BagKeyStartOfString: true,
-		}
-	}
-
-	expr := r1.Val.(Node)
-
-	return combinator.Result{
-		Val: expr,
-		Pos: pos,
-		Bag: bag,
-	}, nil
+	// Passing the result up
+	return r, nil
 }
 
 //==================================================< HELPERS >==================================================

--- a/internal/regex/parser/ast/ast_test.go
+++ b/internal/regex/parser/ast/ast_test.go
@@ -134,7 +134,7 @@ var testAST = map[string]*AST{
 			4: {5},
 		},
 	},
-	`^[a-f][0-9a-f]*$`: {
+	`[a-f][0-9a-f]*`: {
 		Root: &Concat{
 			Exprs: []Node{
 				&Concat{
@@ -242,7 +242,6 @@ func TestParse_Sanity(t *testing.T) {
 	regexes := []string{
 		// Escaped characters
 		`\\`, `\t`, `\n`, `\r`,
-		`\^`, `\$`,
 		`\|`, `\.`,
 		`\?`, `\*`, `\+`,
 		`\(`, `\)`, `\[`, `\]`, `\{`, `\}`,
@@ -355,8 +354,8 @@ func TestParse_Verify(t *testing.T) {
 			expectedLastPos:  Poses{5},
 		},
 		{
-			regex:            `^[a-f][0-9a-f]*$`,
-			expectedAST:      testAST[`^[a-f][0-9a-f]*$`],
+			regex:            `[a-f][0-9a-f]*`,
+			expectedAST:      testAST[`[a-f][0-9a-f]*`],
 			expectedNullable: false,
 			expectedFirstPos: Poses{1},
 			expectedLastPos:  Poses{4},
@@ -434,7 +433,7 @@ func TestAST_DOT(t *testing.T) {
 	}{
 		{
 			name: "OK",
-			a:    testAST[`^[a-f][0-9a-f]*$`],
+			a:    testAST[`[a-f][0-9a-f]*`],
 			expectedDOT: `strict digraph "AST" {
   concentrate=false;
   node [];
@@ -468,7 +467,7 @@ func TestAST_DOT(t *testing.T) {
 }
 
 func TestTraverse(t *testing.T) {
-	root := testAST[`^[a-f][0-9a-f]*$`].Root
+	root := testAST[`[a-f][0-9a-f]*`].Root
 
 	tests := []struct {
 		name           string
@@ -3053,38 +3052,6 @@ func TestMappers_ToGroup(t *testing.T) {
 	}
 }
 
-func TestMappers_ToAnchor(t *testing.T) {
-	tests := []MapperTest{
-		{
-			name: "Success",
-			r: combinator.Result{
-				Val: '$',
-				Pos: 2,
-			},
-			expectedResult: combinator.Result{
-				Val: EndOfString,
-				Pos: 2,
-			},
-			expectedError: "",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			m := new(mappers)
-			res, err := m.ToAnchor(tc.r)
-
-			if tc.expectedError == "" {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.expectedResult, res)
-			} else {
-				assert.Empty(t, res)
-				assert.EqualError(t, err, tc.expectedError)
-			}
-		})
-	}
-}
-
 func TestMappers_ToSubexprItem(t *testing.T) {
 	tests := []MapperTest{
 		{
@@ -3260,15 +3227,9 @@ func TestMappers_ToRegex(t *testing.T) {
 		{
 			name: "Success",
 			r: combinator.Result{
-				Val: combinator.List{
-					{Val: combinator.Empty{}},
-					{
-						Val: &Concat{
-							Exprs: []Node{
-								&Char{Lo: 's', Hi: 's'},
-							},
-						},
-						Pos: 0,
+				Val: &Concat{
+					Exprs: []Node{
+						&Char{Lo: 's', Hi: 's'},
 					},
 				},
 				Pos: 0,
@@ -3280,35 +3241,6 @@ func TestMappers_ToRegex(t *testing.T) {
 					},
 				},
 				Pos: 0,
-			},
-			expectedError: "",
-		},
-		{
-			name: "Success_WithStartOfString",
-			r: combinator.Result{
-				Val: combinator.List{
-					{Val: '^', Pos: 0},
-					{
-						Val: &Concat{
-							Exprs: []Node{
-								&Char{Lo: 's', Hi: 's'},
-							},
-						},
-						Pos: 1,
-					},
-				},
-				Pos: 0,
-			},
-			expectedResult: combinator.Result{
-				Val: &Concat{
-					Exprs: []Node{
-						&Char{Lo: 's', Hi: 's'},
-					},
-				},
-				Pos: 0,
-				Bag: combinator.Bag{
-					BagKeyStartOfString: true,
-				},
 			},
 			expectedError: "",
 		},

--- a/internal/regex/parser/nfa/nfa.go
+++ b/internal/regex/parser/nfa/nfa.go
@@ -332,21 +332,6 @@ func (m *mappers) ToGroup(r combinator.Result) (combinator.Result, error) {
 	}, nil
 }
 
-func (m *mappers) ToAnchor(r combinator.Result) (combinator.Result, error) {
-	c := r.Val.(rune)
-
-	var anchor Anchor
-	switch c {
-	case '$': // end-of-string
-		anchor = EndOfString
-	}
-
-	return combinator.Result{
-		Val: anchor,
-		Pos: r.Pos,
-	}, nil
-}
-
 func (m *mappers) ToSubexprItem(r combinator.Result) (combinator.Result, error) {
 	// Passing the result up the parsing chain
 	return r, nil
@@ -390,27 +375,8 @@ func (m *mappers) ToExpr(r combinator.Result) (combinator.Result, error) {
 }
 
 func (m *mappers) ToRegex(r combinator.Result) (combinator.Result, error) {
-	r0, _ := r.Get(0)
-	r1, _ := r.Get(1)
-
-	pos := r1.Pos
-	var bag combinator.Bag
-
-	// Check whether or not the start-of-string is present
-	if _, sos := r0.Val.(rune); sos {
-		pos = r0.Pos
-		bag = combinator.Bag{
-			BagKeyStartOfString: true,
-		}
-	}
-
-	nfa := r1.Val.(*automata.NFA)
-
-	return combinator.Result{
-		Val: nfa,
-		Pos: pos,
-		Bag: bag,
-	}, nil
+	// Passing the result up
+	return r, nil
 }
 
 //==================================================< HELPERS >==================================================

--- a/internal/regex/parser/nfa/nfa_test.go
+++ b/internal/regex/parser/nfa/nfa_test.go
@@ -510,7 +510,6 @@ func TestParse_Sanity(t *testing.T) {
 	regexes := []string{
 		// Escaped characters
 		`\\`, `\t`, `\n`, `\r`,
-		`\^`, `\$`,
 		`\|`, `\.`,
 		`\?`, `\*`, `\+`,
 		`\(`, `\)`, `\[`, `\]`, `\{`, `\}`,
@@ -614,7 +613,7 @@ func TestParse_Verify(t *testing.T) {
 			),
 		},
 		{
-			regex: `^[A-Z]?[a-z][0-9A-Za-z]{1,}$`,
+			regex: `[A-Z]?[a-z][0-9A-Za-z]{1,}`,
 			expectedNFA: empty().Union(testNFA["upper"]).Concat(
 				testNFA["lower"],
 				testNFA["alnum"].Concat(testNFA["alnum"].Star()),
@@ -2187,38 +2186,6 @@ func TestMappers_ToGroup(t *testing.T) {
 	}
 }
 
-func TestMappers_ToAnchor(t *testing.T) {
-	tests := []MapperTest{
-		{
-			name: "Success",
-			r: combinator.Result{
-				Val: '$',
-				Pos: 2,
-			},
-			expectedResult: combinator.Result{
-				Val: EndOfString,
-				Pos: 2,
-			},
-			expectedError: "",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			m := new(mappers)
-			res, err := m.ToAnchor(tc.r)
-
-			if tc.expectedError == "" {
-				assert.NoError(t, err)
-				assertEqualResults(t, tc.expectedResult, res)
-			} else {
-				assert.Empty(t, res)
-				assert.EqualError(t, err, tc.expectedError)
-			}
-		})
-	}
-}
-
 func TestMappers_ToSubexprItem(t *testing.T) {
 	tests := []MapperTest{
 		{
@@ -2361,39 +2328,12 @@ func TestMappers_ToRegex(t *testing.T) {
 		{
 			name: "Success",
 			r: combinator.Result{
-				Val: combinator.List{
-					{Val: combinator.Empty{}},
-					{
-						Val: testNFA["digit"],
-						Pos: 0,
-					},
-				},
+				Val: testNFA["digit"],
 				Pos: 0,
 			},
 			expectedResult: combinator.Result{
 				Val: testNFA["digit"],
 				Pos: 0,
-			},
-			expectedError: "",
-		},
-		{
-			name: "Success_WithStartOfString",
-			r: combinator.Result{
-				Val: combinator.List{
-					{Val: '^', Pos: 0},
-					{
-						Val: testNFA["digit"],
-						Pos: 1,
-					},
-				},
-				Pos: 0,
-			},
-			expectedResult: combinator.Result{
-				Val: testNFA["digit"],
-				Pos: 0,
-				Bag: combinator.Bag{
-					BagKeyStartOfString: true,
-				},
 			},
 			expectedError: "",
 		},

--- a/internal/regex/parser/parser_test.go
+++ b/internal/regex/parser/parser_test.go
@@ -210,28 +210,6 @@ func TestToEscapedChar(t *testing.T) {
 			expectedError:  "",
 		},
 		{
-			name: "Caret",
-			r: comb.Result{
-				Val: comb.List{
-					{Val: '\\', Pos: 1},
-					{Val: '^', Pos: 2},
-				},
-			},
-			expectedResult: comb.Result{Val: '^', Pos: 1},
-			expectedError:  "",
-		},
-		{
-			name: "Dollar",
-			r: comb.Result{
-				Val: comb.List{
-					{Val: '\\', Pos: 1},
-					{Val: '$', Pos: 2},
-				},
-			},
-			expectedResult: comb.Result{Val: '$', Pos: 1},
-			expectedError:  "",
-		},
-		{
 			name: "Bar",
 			r: comb.Result{
 				Val: comb.List{
@@ -852,20 +830,6 @@ func TestParser_rawChar(t *testing.T) {
 			expectedError: "0: unexpected rune '\\r'",
 		},
 		{
-			name:          "Caret",
-			m:             &mockMappers{},
-			in:            newStringInput(`^`),
-			expectedOut:   nil,
-			expectedError: "0: unexpected rune '^'",
-		},
-		{
-			name:          "Dollar",
-			m:             &mockMappers{},
-			in:            newStringInput(`$`),
-			expectedOut:   nil,
-			expectedError: "0: unexpected rune '$'",
-		},
-		{
 			name:          "Bar",
 			m:             &mockMappers{},
 			in:            newStringInput(`|`),
@@ -1026,24 +990,6 @@ func TestParser_escapedChar(t *testing.T) {
 			in:   newStringInput(`\r`),
 			expectedOut: &comb.Output{
 				Result: comb.Result{Val: '\r', Pos: 0},
-			},
-			expectedError: "",
-		},
-		{
-			name: "Success_Caret",
-			m:    &mockMappers{},
-			in:   newStringInput(`\^`),
-			expectedOut: &comb.Output{
-				Result: comb.Result{Val: '^', Pos: 0},
-			},
-			expectedError: "",
-		},
-		{
-			name: "Success_Dollar",
-			m:    &mockMappers{},
-			in:   newStringInput(`\$`),
-			expectedOut: &comb.Output{
-				Result: comb.Result{Val: '$', Pos: 0},
 			},
 			expectedError: "",
 		},
@@ -5291,44 +5237,6 @@ func TestParser_group(t *testing.T) {
 	}
 }
 
-func TestParser_anchor(t *testing.T) {
-	tests := []struct {
-		name             string
-		m                *mockMappers
-		in               comb.Input
-		expectedInResult comb.Result
-	}{
-		{
-			name:             "Failure",
-			m:                &mockMappers{},
-			in:               newStringInput(`#`),
-			expectedInResult: comb.Result{},
-		},
-		{
-			name: "Success",
-			m: &mockMappers{
-				ToAnchorMocks: []MapFuncMock{
-					{},
-				},
-			},
-			in:               newStringInput(`$`),
-			expectedInResult: comb.Result{Val: '$', Pos: 0},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			p := New(tc.m)
-			_, _ = p.anchor(tc.in)
-
-			// Verify the expected result has been passed to the mapper function
-			if m := tc.m.ToAnchorMocks; len(m) > 0 {
-				assert.Equal(t, tc.expectedInResult, m[len(m)-1].InResult)
-			}
-		})
-	}
-}
-
 func TestParser_subexprItem(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -5340,19 +5248,6 @@ func TestParser_subexprItem(t *testing.T) {
 			name:             "Failure",
 			m:                &mockMappers{},
 			in:               newStringInput(`\`),
-			expectedInResult: comb.Result{},
-		},
-		{
-			name: "Success_Anchor",
-			m: &mockMappers{
-				ToAnchorMocks: []MapFuncMock{
-					{OutError: nil},
-				},
-				ToSubexprItemMocks: []MapFuncMock{
-					{},
-				},
-			},
-			in:               newStringInput(`$`),
 			expectedInResult: comb.Result{},
 		},
 		{
@@ -5591,7 +5486,7 @@ func TestParser_regex(t *testing.T) {
 			expectedInResult: comb.Result{},
 		},
 		{
-			name: "Success_WithoutStartOfString",
+			name: "Success",
 			m: &mockMappers{
 				ToSingleCharMocks: []MapFuncMock{
 					{OutError: nil},
@@ -5615,47 +5510,8 @@ func TestParser_regex(t *testing.T) {
 					{},
 				},
 			},
-			in: newStringInput(`a`),
-			expectedInResult: comb.Result{
-				Val: comb.List{
-					{Val: comb.Empty{}},
-					{},
-				},
-			},
-		},
-		{
-			name: "Success_WithStartOfString",
-			m: &mockMappers{
-				ToSingleCharMocks: []MapFuncMock{
-					{OutError: nil},
-				},
-				ToMatchItemMocks: []MapFuncMock{
-					{OutError: nil},
-				},
-				ToMatchMocks: []MapFuncMock{
-					{OutError: nil},
-				},
-				ToSubexprItemMocks: []MapFuncMock{
-					{OutError: nil},
-				},
-				ToSubexprMocks: []MapFuncMock{
-					{OutError: nil},
-				},
-				ToExprMocks: []MapFuncMock{
-					{OutError: nil},
-				},
-				ToRegexMocks: []MapFuncMock{
-					{},
-				},
-			},
-			in: newStringInput(`^a`),
-			expectedInResult: comb.Result{
-				Val: comb.List{
-					{Val: '^', Pos: 0},
-					{},
-				},
-				Pos: 0,
-			},
+			in:               newStringInput(`a`),
+			expectedInResult: comb.Result{},
 		},
 	}
 
@@ -5874,9 +5730,6 @@ type mockMappers struct {
 	ToGroupIndex int
 	ToGroupMocks []MapFuncMock
 
-	ToAnchorIndex int
-	ToAnchorMocks []MapFuncMock
-
 	ToSubexprItemIndex int
 	ToSubexprItemMocks []MapFuncMock
 
@@ -6014,13 +5867,6 @@ func (m *mockMappers) ToGroup(r comb.Result) (comb.Result, error) {
 	m.ToGroupIndex++
 	m.ToGroupMocks[i].InResult = r
 	return m.ToGroupMocks[i].OutResult, m.ToGroupMocks[i].OutError
-}
-
-func (m *mockMappers) ToAnchor(r comb.Result) (comb.Result, error) {
-	i := m.ToAnchorIndex
-	m.ToAnchorIndex++
-	m.ToAnchorMocks[i].InResult = r
-	return m.ToAnchorMocks[i].OutResult, m.ToAnchorMocks[i].OutError
 }
 
 func (m *mockMappers) ToSubexprItem(r comb.Result) (comb.Result, error) {


### PR DESCRIPTION
## Description

Resolves #103 

  - [x] Remove *Start of String* anchor (`^`)
  - [x] Remove *End of String* anchor (`$`)

### Checklist

  - [ ] PR title is clear and describes the change
  - [ ] Commit messages are self-explanatory and summarize the change
  - [ ] Tests are provided for the new change
